### PR TITLE
MR-692 - Asset invalid version check bug fix

### DIFF
--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -66,7 +66,8 @@ export const EditableAddress = ({
       },
     };
 
-    if (assetDetails?.versionNumber) {
+    // the toString() prevents a version with a potential valid value of Number 0 from being seen as 'falsy'
+    if (assetDetails?.versionNumber?.toString()) {
       const assetVersionNumber = assetDetails.versionNumber.toString();
 
       await patchAsset(assetDetails.id, assetAddress, assetVersionNumber)


### PR DESCRIPTION
Bug fix: if the asset being edited has a version of 0 (this is a value of type Number), this is seen as falsy, and so it triggers the invalid version error. However 0 is a valid version value.

The asset version is now converted to a string. 

Number 0.toString() = "0" (Truthy)
null / undefined .toString() = throws error

![image](https://user-images.githubusercontent.com/70756861/225347149-a41fa20c-11e9-42f7-bea4-8322de4ff53a.png)

