### PR TITLE
MR-692 - ReferenceAddress fields visually lighter (looking more "disabled") and removed Asset version check

### DIFF
--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -67,37 +67,31 @@ export const EditableAddress = ({
     };
 
     // the toString() prevents a version with a potential valid value of Number 0 from being seen as 'falsy'
-    if (assetDetails?.versionNumber?.toString()) {
-      const assetVersionNumber = assetDetails.versionNumber.toString();
+    const assetVersionNumber = assetDetails?.versionNumber?.toString()
+      ? assetDetails.versionNumber.toString()
+      : null;
 
-      await patchAsset(assetDetails.id, assetAddress, assetVersionNumber)
-        .then(() => {
-          // If the update is successful, we update the "Current Address" details (postPreamble and UPRN are unchanged)
-          const newAssetAddress: AssetAddress = {
-            addressLine1: assetAddress.assetAddress.addressLine1,
-            addressLine2: assetAddress.assetAddress.addressLine2,
-            addressLine3: assetAddress.assetAddress.addressLine3,
-            addressLine4: assetAddress.assetAddress.addressLine4,
-            postCode: assetAddress.assetAddress.postCode,
-            postPreamble: assetDetails.assetAddress.postPreamble,
-            uprn: assetDetails.assetAddress.uprn,
-          };
-          setCurrentAssetAddress(newAssetAddress);
-          setShowSuccess(true);
-          setSubmitEditEnabled(false);
-        })
-        .catch(() => {
-          setShowError(true);
-          setErrorHeading(locale.errors.unableToPatchAsset);
-          setErrorDescription(locale.errors.tryAgainOrContactSupport);
-        });
-    } else {
-      setShowError(true);
-      setErrorHeading(locale.errors.unableToPatchAsset);
-      setErrorDescription(
-        `Asset "version" invalid (value: ${assetDetails?.versionNumber}). This is a required property when updating the asset. If the issue persists, please contact support.`,
-      );
-    }
+    await patchAsset(assetDetails.id, assetAddress, assetVersionNumber)
+      .then(() => {
+        // If the update is successful, we update the "Current Address" details (postPreamble and UPRN are unchanged)
+        const newAssetAddress: AssetAddress = {
+          addressLine1: assetAddress.assetAddress.addressLine1,
+          addressLine2: assetAddress.assetAddress.addressLine2,
+          addressLine3: assetAddress.assetAddress.addressLine3,
+          addressLine4: assetAddress.assetAddress.addressLine4,
+          postCode: assetAddress.assetAddress.postCode,
+          postPreamble: assetDetails.assetAddress.postPreamble,
+          uprn: assetDetails.assetAddress.uprn,
+        };
+        setCurrentAssetAddress(newAssetAddress);
+        setShowSuccess(true);
+        setSubmitEditEnabled(false);
+      })
+      .catch(() => {
+        setShowError(true);
+        setErrorHeading(locale.errors.unableToPatchAsset);
+        setErrorDescription(locale.errors.tryAgainOrContactSupport);
+      });
   };
 
   if (!llpgAddress && loading) {
@@ -201,7 +195,7 @@ export const EditableAddress = ({
                 }
               >
                 <label className="govuk-label lbh-label" htmlFor="postcode">
-                  Postcode
+                  Postcode*
                 </label>
                 <span
                   id="Postcode-input-error"

--- a/src/components/edit-asset-address-form/reference-address/reference-address.tsx
+++ b/src/components/edit-asset-address-form/reference-address/reference-address.tsx
@@ -16,7 +16,10 @@ export const ReferenceAddress = ({
       <h3 className="lbh-heading-h3">Current address</h3>
 
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label grey-text" htmlFor="asset-address-line-one-input">
+        <label
+          className="govuk-label lbh-label grey-text"
+          htmlFor="asset-address-line-one-input"
+        >
           Address line 1
         </label>
         <input
@@ -31,7 +34,10 @@ export const ReferenceAddress = ({
         />
       </div>
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label grey-text" htmlFor="asset-address-line-two-input">
+        <label
+          className="govuk-label lbh-label grey-text"
+          htmlFor="asset-address-line-two-input"
+        >
           Address line 2
         </label>
         <input
@@ -45,7 +51,10 @@ export const ReferenceAddress = ({
         />
       </div>
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label grey-text" htmlFor="asset-address-line-three">
+        <label
+          className="govuk-label lbh-label grey-text"
+          htmlFor="asset-address-line-three"
+        >
           Address line 3
         </label>
         <input
@@ -59,7 +68,10 @@ export const ReferenceAddress = ({
         />
       </div>
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label grey-text" htmlFor="asset-address-line-four-input">
+        <label
+          className="govuk-label lbh-label grey-text"
+          htmlFor="asset-address-line-four-input"
+        >
           Address line 4
         </label>
         <input

--- a/src/components/edit-asset-address-form/reference-address/reference-address.tsx
+++ b/src/components/edit-asset-address-form/reference-address/reference-address.tsx
@@ -16,8 +16,8 @@ export const ReferenceAddress = ({
       <h3 className="lbh-heading-h3">Current address</h3>
 
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label" htmlFor="asset-address-line-one-input">
-          Address line 1*
+        <label className="govuk-label lbh-label grey-text" htmlFor="asset-address-line-one-input">
+          Address line 1
         </label>
         <input
           className="govuk-input lbh-input"
@@ -31,7 +31,7 @@ export const ReferenceAddress = ({
         />
       </div>
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label" htmlFor="asset-address-line-two-input">
+        <label className="govuk-label lbh-label grey-text" htmlFor="asset-address-line-two-input">
           Address line 2
         </label>
         <input
@@ -45,7 +45,7 @@ export const ReferenceAddress = ({
         />
       </div>
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label" htmlFor="asset-address-line-three">
+        <label className="govuk-label lbh-label grey-text" htmlFor="asset-address-line-three">
           Address line 3
         </label>
         <input
@@ -59,7 +59,7 @@ export const ReferenceAddress = ({
         />
       </div>
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label" htmlFor="asset-address-line-four-input">
+        <label className="govuk-label lbh-label grey-text" htmlFor="asset-address-line-four-input">
           Address line 4
         </label>
         <input
@@ -73,7 +73,7 @@ export const ReferenceAddress = ({
         />
       </div>
       <div className="govuk-form-group lbh-form-group">
-        <label className="govuk-label lbh-label" htmlFor="asset-postcode-input">
+        <label className="govuk-label lbh-label grey-text" htmlFor="asset-postcode-input">
           Postcode
         </label>
         <input

--- a/src/components/edit-asset-address-form/styles.scss
+++ b/src/components/edit-asset-address-form/styles.scss
@@ -4,7 +4,18 @@ label {
     margin: 28.5px 0px 6px
 }
 
+.grey-text {
+    color: #505a5f;
+}
+
 .form-actions {
     display: flex;
     justify-content: space-between;
+}
+
+input:disabled {
+    cursor: default;
+    background-color: -internal-light-dark(rgba(239, 239, 239, 0.3), rgba(59, 59, 59, 0.3));
+    color: #505a5f;
+    border-color: rgba(118, 118, 118, 0.3);
 }

--- a/src/views/asset-edit-view/__snapshots__/asset-edit-view.test.tsx.snap
+++ b/src/views/asset-edit-view/__snapshots__/asset-edit-view.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`renders the whole 'Edit property address' view 1`] = `
               class="govuk-label lbh-label"
               for="postcode"
             >
-              Postcode
+              Postcode*
             </label>
             <span
               class="govuk-error-message lbh-error-message"
@@ -163,10 +163,10 @@ exports[`renders the whole 'Edit property address' view 1`] = `
         class="govuk-form-group lbh-form-group"
       >
         <label
-          class="govuk-label lbh-label"
+          class="govuk-label lbh-label grey-text"
           for="asset-address-line-one-input"
         >
-          Address line 1*
+          Address line 1
         </label>
         <input
           class="govuk-input lbh-input"
@@ -183,7 +183,7 @@ exports[`renders the whole 'Edit property address' view 1`] = `
         class="govuk-form-group lbh-form-group"
       >
         <label
-          class="govuk-label lbh-label"
+          class="govuk-label lbh-label grey-text"
           for="asset-address-line-two-input"
         >
           Address line 2
@@ -202,7 +202,7 @@ exports[`renders the whole 'Edit property address' view 1`] = `
         class="govuk-form-group lbh-form-group"
       >
         <label
-          class="govuk-label lbh-label"
+          class="govuk-label lbh-label grey-text"
           for="asset-address-line-three"
         >
           Address line 3
@@ -221,7 +221,7 @@ exports[`renders the whole 'Edit property address' view 1`] = `
         class="govuk-form-group lbh-form-group"
       >
         <label
-          class="govuk-label lbh-label"
+          class="govuk-label lbh-label grey-text"
           for="asset-address-line-four-input"
         >
           Address line 4
@@ -240,7 +240,7 @@ exports[`renders the whole 'Edit property address' view 1`] = `
         class="govuk-form-group lbh-form-group"
       >
         <label
-          class="govuk-label lbh-label"
+          class="govuk-label lbh-label grey-text"
           for="asset-postcode-input"
         >
           Postcode


### PR DESCRIPTION
REFERENCE ADDRESS FIELDS:

ReferenceAddress readonly fields now look lighter, as disabled field should look.

![image](https://user-images.githubusercontent.com/70756861/225710526-df63f888-a135-4fde-914c-b3b0a6bc9698.png)

PATCH ASSET VERSION VALIDATION REMOVED:

After numerous tests with Postman, we've established that sending a 'null' asset version works fine with the way Asset API is set up currently.

The Asset, that initially has a versionNumber of 'null', now gets PATCH'ed correctly when sending 'null' into patchAsset, and its versionNumber gets then updated automatically to a value of 0 (by DynamoDb)

![image](https://user-images.githubusercontent.com/70756861/225708546-caf803d8-4ce1-46cb-8d7f-2eeb186d88ae.png)

![image](https://user-images.githubusercontent.com/70756861/225708560-72f9a4fb-feae-4421-9f4f-4fc4caf74139.png)
