### PR TITLE
MR-692 - Changes after successful submission of edited asset address

### DIFF
--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -46,7 +46,43 @@ export const EditableAddress = ({
   setErrorDescription,
   setCurrentAssetAddress,
 }: EditableAddressProperties): JSX.Element => {
-  const [submitEditEnabled, setSubmitEditEnabled] = useState<boolean>(true);
+  const [addressEditSuccessful, setAddressEditSuccessful] = useState<boolean>(false);
+
+  const renderFormActionButtons = () => {
+    if (!addressEditSuccessful) {
+      return (
+        <>
+          <div className="form-actions">
+            <button
+              className="govuk-button lbh-button"
+              data-module="govuk-button"
+              type="submit"
+              id="submit-address-button"
+            >
+              Update to this address
+            </button>
+
+            <RouterLink
+              to={`/property/${assetDetails.id}`}
+              className="govuk-button govuk-secondary lbh-button lbh-button--secondary"
+            >
+              Cancel
+            </RouterLink>
+          </div>
+        </>
+      );
+    }
+    return (
+      <>
+        <RouterLink
+          to={`/property/${assetDetails.id}`}
+          className="govuk-button lbh-button"
+        >
+          Back to property view
+        </RouterLink>
+      </>
+    );
+  };
 
   const handleSubmit = async (values: PatchAssetFormValues) => {
     setShowSuccess(false);
@@ -85,7 +121,7 @@ export const EditableAddress = ({
         };
         setCurrentAssetAddress(newAssetAddress);
         setShowSuccess(true);
-        setSubmitEditEnabled(false);
+        setAddressEditSuccessful(true);
       })
       .catch(() => {
         setShowError(true);
@@ -131,18 +167,25 @@ export const EditableAddress = ({
                     : "govuk-form-group lbh-form-group"
                 }
               >
-                <label className="govuk-label lbh-label" htmlFor="addressLine1">
+                <label
+                  className={
+                    addressEditSuccessful
+                      ? "govuk-label lbh-label grey-text"
+                      : "govuk-label lbh-label"
+                  }
+                  htmlFor="address-line-1"
+                >
                   Address line 1*
                 </label>
                 <span
-                  id="addressLine1-input-error"
+                  id="address-line-1-input-error"
                   className="govuk-error-message lbh-error-message"
                 >
                   <span className="govuk-visually-hidden">Error:</span>
                   {errors.addressLine1}
                 </span>
                 <Field
-                  id="addressLine1"
+                  id="address-line-1"
                   name="addressLine1"
                   className={
                     errors.addressLine1 && touched.addressLine1
@@ -150,41 +193,66 @@ export const EditableAddress = ({
                       : "govuk-input lbh-input"
                   }
                   type="text"
-                  data-testid="addressLine1"
+                  data-testid="address-line-1"
+                  disabled={!!addressEditSuccessful}
                 />
               </div>
 
-              <label className="govuk-label lbh-label" htmlFor="addressLine2">
+              <label
+                className={
+                  addressEditSuccessful
+                    ? "govuk-label lbh-label grey-text"
+                    : "govuk-label lbh-label"
+                }
+                htmlFor="address-line-2"
+              >
                 Address line 2
               </label>
               <Field
-                id="addressLine2"
+                id="address-line-2"
                 name="addressLine2"
                 className="govuk-input lbh-input"
                 type="text"
-                data-testid="addressLine2"
+                data-testid="address-line-2"
+                disabled={!!addressEditSuccessful}
               />
 
-              <label className="govuk-label lbh-label" htmlFor="addressLine3">
+              <label
+                className={
+                  addressEditSuccessful
+                    ? "govuk-label lbh-label grey-text"
+                    : "govuk-label lbh-label"
+                }
+                htmlFor="address-line-3"
+              >
                 Address line 3
               </label>
               <Field
-                id="addressLine3"
+                id="address-line-3"
                 name="addressLine3"
                 className="govuk-input lbh-input"
                 type="text"
-                data-testid="addressLine3"
+                data-testid="address-line-3"
+                disabled={!!addressEditSuccessful}
               />
 
-              <label className="govuk-label lbh-label" htmlFor="addressLine4">
+              <label
+                className={
+                  addressEditSuccessful
+                    ? "govuk-label lbh-label grey-text"
+                    : "govuk-label lbh-label"
+                }
+                htmlFor="address-line-4"
+              >
                 Address line 4
               </label>
               <Field
-                id="addressLine4"
+                id="address-line-4"
                 name="addressLine4"
                 className="govuk-input lbh-input"
                 type="text"
-                data-testid="addressLine4"
+                data-testid="address-line-4"
+                disabled={!!addressEditSuccessful}
               />
 
               <div
@@ -194,7 +262,14 @@ export const EditableAddress = ({
                     : "govuk-form-group lbh-form-group"
                 }
               >
-                <label className="govuk-label lbh-label" htmlFor="postcode">
+                <label
+                  className={
+                    addressEditSuccessful
+                      ? "govuk-label lbh-label grey-text"
+                      : "govuk-label lbh-label"
+                  }
+                  htmlFor="postcode"
+                >
                   Postcode*
                 </label>
                 <span
@@ -213,27 +288,10 @@ export const EditableAddress = ({
                   }
                   type="text"
                   data-testid="postcode"
+                  disabled={!!addressEditSuccessful}
                 />
               </div>
-
-              <div className="form-actions">
-                <button
-                  className="govuk-button lbh-button"
-                  data-module="govuk-button"
-                  type="submit"
-                  id="submit-address-button"
-                  disabled={!submitEditEnabled}
-                >
-                  Update to this address
-                </button>
-
-                <RouterLink
-                  to={`/property/${assetDetails.id}`}
-                  className="govuk-button govuk-secondary lbh-button lbh-button--secondary"
-                >
-                  Cancel edit address
-                </RouterLink>
-              </div>
+              {renderFormActionButtons()}
             </Form>
           </div>
         )}

--- a/src/views/asset-edit-view/__snapshots__/asset-edit-view.test.tsx.snap
+++ b/src/views/asset-edit-view/__snapshots__/asset-edit-view.test.tsx.snap
@@ -38,13 +38,13 @@ exports[`renders the whole 'Edit property address' view 1`] = `
           >
             <label
               class="govuk-label lbh-label"
-              for="addressLine1"
+              for="address-line-1"
             >
               Address line 1*
             </label>
             <span
               class="govuk-error-message lbh-error-message"
-              id="addressLine1-input-error"
+              id="address-line-1-input-error"
             >
               <span
                 class="govuk-visually-hidden"
@@ -54,8 +54,8 @@ exports[`renders the whole 'Edit property address' view 1`] = `
             </span>
             <input
               class="govuk-input lbh-input"
-              data-testid="addressLine1"
-              id="addressLine1"
+              data-testid="address-line-1"
+              id="address-line-1"
               name="addressLine1"
               type="text"
               value="FLAT B"
@@ -63,42 +63,42 @@ exports[`renders the whole 'Edit property address' view 1`] = `
           </div>
           <label
             class="govuk-label lbh-label"
-            for="addressLine2"
+            for="address-line-2"
           >
             Address line 2
           </label>
           <input
             class="govuk-input lbh-input"
-            data-testid="addressLine2"
-            id="addressLine2"
+            data-testid="address-line-2"
+            id="address-line-2"
             name="addressLine2"
             type="text"
             value="51 GREENWOOD ROAD"
           />
           <label
             class="govuk-label lbh-label"
-            for="addressLine3"
+            for="address-line-3"
           >
             Address line 3
           </label>
           <input
             class="govuk-input lbh-input"
-            data-testid="addressLine3"
-            id="addressLine3"
+            data-testid="address-line-3"
+            id="address-line-3"
             name="addressLine3"
             type="text"
             value="HACKNEY"
           />
           <label
             class="govuk-label lbh-label"
-            for="addressLine4"
+            for="address-line-4"
           >
             Address line 4
           </label>
           <input
             class="govuk-input lbh-input"
-            data-testid="addressLine4"
-            id="addressLine4"
+            data-testid="address-line-4"
+            id="address-line-4"
             name="addressLine4"
             type="text"
             value="LONDON"
@@ -147,7 +147,7 @@ exports[`renders the whole 'Edit property address' view 1`] = `
               class="govuk-button govuk-secondary lbh-button lbh-button--secondary"
               href="/property/15adc44b-6fde-46e8-af9c-e18b1495c9ab"
             >
-              Cancel edit address
+              Cancel
             </a>
           </div>
         </form>

--- a/src/views/asset-edit-view/asset-edit-view.test.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.test.tsx
@@ -133,7 +133,7 @@ test("the current address from the asset is updated using the LLPG address sugge
   await waitFor(() => expect(screen.getAllByRole("heading")).toHaveLength(3));
 
   // Assert LLPG Address Line 1 is FLAT B
-  const llpgAddressLine1 = screen.getByTestId("addressLine1");
+  const llpgAddressLine1 = screen.getByTestId("address-line-1");
   expect(llpgAddressLine1).toHaveValue("FLAT B");
 
   // Assert Asset Address Line 1 is 51 GREENWOOD ROAD - FLAT B
@@ -141,7 +141,7 @@ test("the current address from the asset is updated using the LLPG address sugge
   expect(assetAddressLine1).toHaveValue("51 GREENWOOD ROAD - FLAT B");
 
   // Assert LLPG AddrLine2 is 51 GREENWOOD ROAD
-  const llpgAddressLine2 = screen.getByTestId("addressLine2");
+  const llpgAddressLine2 = screen.getByTestId("address-line-2");
   expect(llpgAddressLine2).toHaveValue("51 GREENWOOD ROAD");
 
   // Assert Asset AddrLine2 is ""
@@ -149,7 +149,7 @@ test("the current address from the asset is updated using the LLPG address sugge
   expect(assetAddressLine2).toHaveValue("");
 
   // Assert LLPG AddrLine3 is HACKNEY
-  const llpgAddressLine3 = screen.getByTestId("addressLine3");
+  const llpgAddressLine3 = screen.getByTestId("address-line-3");
   expect(llpgAddressLine3).toHaveValue("HACKNEY");
 
   // Assert Asset AddrLine3 is ""
@@ -157,7 +157,7 @@ test("the current address from the asset is updated using the LLPG address sugge
   expect(assetAddressLine3).toHaveValue("");
 
   // Assert LLPG AddrLine4 is LONDON
-  const llpgAddressLine4 = screen.getByTestId("addressLine4");
+  const llpgAddressLine4 = screen.getByTestId("address-line-4");
   expect(llpgAddressLine4).toHaveValue("LONDON");
 
   // Assert Asset AddrLine4 is ""


### PR DESCRIPTION
Prior to this PR, the following is what would happen after the successful editing of an address:

- User submits edited asset address
- If successful >
- Success message shown
- Current address data (on the right) changes with the new data
- Submit button disabled

The new behaviour introduced by this PR:
- User submits edited asset address
- If successful >
- Success message shown
- Current address data (on the right) changes with the new data
- "Update to this address" and "Cancel" buttons are replaced by one "Back to asset view" button, which redirects the user to the main property view
- Editable fields are disabled

This way the user can no longer do anything on the page, other than returning to the "main asset view" using the button or the link at the top of the page.

Before sending edit request:
![image](https://user-images.githubusercontent.com/70756861/226955221-9009473b-8f05-4fe1-9245-7898588d41a6.png)

After sending edit request:
![image](https://user-images.githubusercontent.com/70756861/226955357-0118f15c-a0d0-4395-8b22-2026315a291e.png)
