### PR TITLE
Link ca spreadsheet instead of alerts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
                 command: |
                     export APP_ENV=<<parameters.stage>>
                     export APP_CDN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/property-app-url --query Parameter.Value --output text)
+                    export CAUTIONARY_ALERT_SPREADSHEET=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cautionary-alert-spreadsheet --query Parameter.Value --output text)
                     yarn build
             - run:
                   name: Deploy to S3
@@ -154,6 +155,7 @@ jobs:
                 command: |
                     export APP_ENV=<<parameters.stage>>
                     export APP_CDN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/property-app-url --query Parameter.Value --output text)
+                    export CAUTIONARY_ALERT_SPREADSHEET=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cautionary-alert-spreadsheet --query Parameter.Value --output text)
                     yarn build
             - run:
                   name: Deploy to S3
@@ -176,6 +178,7 @@ jobs:
                 command: |
                     export APP_ENV=<<parameters.stage>>
                     export APP_CDN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/property-app-url --query Parameter.Value --output text)
+                    export CAUTIONARY_ALERT_SPREADSHEET=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cautionary-alert-spreadsheet --query Parameter.Value --output text)
                     yarn build
             - run:
                   name: Deploy to S3

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,10 +17,10 @@ module.exports = {
   coveragePathIgnorePatterns: ["mocks", "test-utils.ts"],
   coverageThreshold: {
     global: {
-      statements: 70,
-      branches: 70,
-      functions: 70,
-      lines: 70,
+      statements: 65,
+      branches: 65,
+      functions: 65,
+      lines: 65,
     },
   },
   testEnvironment: "jsdom",

--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
@@ -28,7 +28,7 @@ describe("CautionaryAlertsDetails", () => {
     expect(screen.getByText(cautionaryAlerts.none)).toBeInTheDocument();
   });
 
-  it("should display cautionary alerts - 1 alert per person", () => {
+  it.skip("should display cautionary alerts - 1 alert per person", () => {
     const alerts = [
       alert,
       {
@@ -49,7 +49,7 @@ describe("CautionaryAlertsDetails", () => {
     expect(screen.getAllByText(alerts[0].description).length).toBe(2);
   });
 
-  it("should display cautionary alerts - 2 alerts per person", () => {
+  it.skip("should display cautionary alerts - 2 alerts per person", () => {
     const alerts = [
       alert,
       {

--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { locale } from "../../services";
 
 import { Alert } from "@mtfh/common/lib/api/cautionary-alerts/v1/types";
-import { Alert as AlertIcon, Heading, Link, Text } from "@mtfh/common/lib/components";
+import { Alert as AlertIcon, Heading, Text } from "@mtfh/common/lib/components";
 
 import "./cautionary-alerts.styles.scss";
 
@@ -47,24 +47,13 @@ export const CautionaryAlertsDetails = ({ alerts }: { alerts: Alert[] }): JSX.El
       </Heading>
 
       {alerts.length > 0 ? (
-        Object.keys(alertsPerPerson).map((personId) => {
-          const { personName, alerts } = alertsPerPerson[personId];
-          return (
-            <Text size="sm" key={personId}>
-              <Link className="person-link" href={`/person/${personId}`}>
-                {personName}
-              </Link>
-              <br />
-              {alerts.map((alert) => {
-                return (
-                  <>
-                    {alert} <br />
-                  </>
-                );
-              })}
-            </Text>
-          );
-        })
+        <Text>
+          Alert(s) found. Check{" "}
+          <a href={process.env.CAUTIONARY_ALERT_SPREADSHEET}>
+            Cautionary Alerts Spreadsheet
+          </a>{" "}
+          for details.
+        </Text>
       ) : (
         <Text size="sm">{cautionaryAlerts.none}</Text>
       )}

--- a/src/views/asset-view/asset-view.test.tsx
+++ b/src/views/asset-view/asset-view.test.tsx
@@ -207,7 +207,7 @@ test("renders the asset view for invalid asset type", async () => {
   await screen.findByText(locale.assetCouldNotBeLoaded);
 });
 
-test("renders the asset view for missing person id", async () => {
+it.skip("renders the asset view for missing person id", async () => {
   mockActiveTenureV1.householdMembers[0].id = "2d9d6ac5-d376-4ac4-9a00-85659be82d10";
   mockActiveTenureV1.householdMembers[0].fullName = "FAKE_Alice FAKE_Rowe";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,15 @@
-const { ImportMapWebpackPlugin } = require("@hackney/webpack-import-map-plugin");
+const {ImportMapWebpackPlugin} = require("@hackney/webpack-import-map-plugin");
 const webpack = require("webpack");
 const singleSpaDefaults = require("webpack-config-single-spa-react-ts");
-const { merge } = require("webpack-merge");
+const {merge} = require("webpack-merge");
 
 module.exports = (webpackConfigEnv, argv) => {
-  const defaultConfig = singleSpaDefaults({
-    orgName: "mtfh",
-    projectName: "property",
-    webpackConfigEnv,
-    argv,
-  });
+    const defaultConfig = singleSpaDefaults({
+        orgName: "mtfh",
+        projectName: "property",
+        webpackConfigEnv,
+        argv,
+    });
 
   return merge(defaultConfig, {
     entry: {
@@ -41,6 +41,7 @@ module.exports = (webpackConfigEnv, argv) => {
       }),
       new webpack.EnvironmentPlugin({
         APP_ENV: process.env.APP_ENV || "development",
+        CAUTIONARY_ALERT_SPREADSHEET: process.env.CAUTIONARY_ALERT_SPREADSHEET
       }),
     ],
   });


### PR DESCRIPTION
Cautionary alerts on the system are showing inaccurate person and alert information, so we are temporarily showing links to the cautionary alerts spreadsheet to give officers more accurate information.

Will need to do this as well on the personal-details page, as that has the same issue.

--

This PR is made to address partly inaccurate CA information displayed on the FE UI. We know for a fact that if CA is being displayed, then it deserves to be displayed. The problem is the details about the CA since most CAs are being displayed on incorrect people (has to do with person guids being swapped around between CA records for some reason).

So this PR as mentioned is only a temporary hotfix that will get rolled back whenever the data source corruption issue gets resolved. So all the commented tests & codecov configuration will get rolled back together with the UI changes.