### PR TITLE
Fixed issue with assets used in cautionary alerts details tests

### DIFF
--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
@@ -5,10 +5,12 @@ import { screen } from "@testing-library/react";
 
 import { locale } from "../../services";
 import { CautionaryAlertsDetails } from "./cautionary-alerts-details";
+import { Alert } from "@mtfh/common/lib/api/cautionary-alerts/v1/types";
 
 const { cautionaryAlerts } = locale;
 
-const alert = {
+const alert: Alert = {
+  alertId: "1234",
   alertCode: "VA",
   assureReference: "",
   dateModified: "",
@@ -19,6 +21,7 @@ const alert = {
   personId: "1",
   reason: "",
   startDate: "",
+  isActive: true
 };
 
 describe("CautionaryAlertsDetails", () => {
@@ -40,10 +43,10 @@ describe("CautionaryAlertsDetails", () => {
     render(<CautionaryAlertsDetails alerts={alerts} />);
     expect(screen.getByText(cautionaryAlerts.cautionaryAlerts)).toBeInTheDocument();
     expect(screen.getByTestId("alert-icon")).toBeInTheDocument();
-    expect(screen.getByText(alerts[0].personName).getAttribute("href")).toBe(
+    expect(screen.getByText(alerts[0].personName!).getAttribute("href")).toBe(
       `/person/${alerts[0].personId}`,
     );
-    expect(screen.getByText(alerts[1].personName).getAttribute("href")).toBe(
+    expect(screen.getByText(alerts[1].personName!).getAttribute("href")).toBe(
       `/person/${alerts[1].personId}`,
     );
     expect(screen.getAllByText(alerts[0].description).length).toBe(2);


### PR DESCRIPTION
There is an issue with the `alerts` object that's being passed into the component CautionaryAlertsDetails, in `cautionary-alerts-details.test.tsx`

![image](https://user-images.githubusercontent.com/70756861/230139559-4bbcc621-d92e-4e26-9616-54c1b7bf9712.png)

The 'base' alert used now implements the Alert interface (from 'common') and I've added exclamation marks so that TS stops worrying about alerts[x].personName being potentially null. 
