### PR TITLE
Fixed issue with assets used in cautionary alerts details tests - Updated 'Common' commit hash in Yarn.Lock

### DIFF
--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
@@ -75,10 +75,10 @@ describe("CautionaryAlertsDetails", () => {
     ];
     render(<CautionaryAlertsDetails alerts={alerts} />);
     expect(screen.getByTestId("alert-icon")).toBeInTheDocument();
-    expect(screen.getByText(alerts[0].personName).getAttribute("href")).toBe(
+    expect(screen.getByText(alerts[0].personName!).getAttribute("href")).toBe(
       `/person/${alerts[0].personId}`,
     );
-    expect(screen.getByText(alerts[1].personName).getAttribute("href")).toBe(
+    expect(screen.getByText(alerts[1].personName!).getAttribute("href")).toBe(
       `/person/${alerts[1].personId}`,
     );
     expect(screen.getAllByText(alerts[0].description, { exact: false }).length).toBe(2);

--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
@@ -5,6 +5,7 @@ import { screen } from "@testing-library/react";
 
 import { locale } from "../../services";
 import { CautionaryAlertsDetails } from "./cautionary-alerts-details";
+
 import { Alert } from "@mtfh/common/lib/api/cautionary-alerts/v1/types";
 
 const { cautionaryAlerts } = locale;
@@ -21,7 +22,7 @@ const alert: Alert = {
   personId: "1",
   reason: "",
   startDate: "",
-  isActive: true
+  isActive: true,
 };
 
 describe("CautionaryAlertsDetails", () => {

--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
@@ -5,10 +5,12 @@ import { screen } from "@testing-library/react";
 
 import { locale } from "../../services";
 import { CautionaryAlertsDetails } from "./cautionary-alerts-details";
+import { Alert } from "@mtfh/common/lib/api/cautionary-alerts/v1/types";
 
 const { cautionaryAlerts } = locale;
 
-const alert = {
+const alert: Alert = {
+  alertId: "1234",
   alertCode: "VA",
   assureReference: "",
   dateModified: "",
@@ -19,6 +21,7 @@ const alert = {
   personId: "1",
   reason: "",
   startDate: "",
+  isActive: true
 };
 
 describe("CautionaryAlertsDetails", () => {
@@ -40,10 +43,10 @@ describe("CautionaryAlertsDetails", () => {
     render(<CautionaryAlertsDetails alerts={alerts} />);
     expect(screen.getByText(cautionaryAlerts.cautionaryAlerts)).toBeInTheDocument();
     expect(screen.getByTestId("alert-icon")).toBeInTheDocument();
-    expect(screen.getByText(alerts[0].personName).getAttribute("href")).toBe(
+    expect(screen.getByText(alerts[0].personName!).getAttribute("href")).toBe(
       `/person/${alerts[0].personId}`,
     );
-    expect(screen.getByText(alerts[1].personName).getAttribute("href")).toBe(
+    expect(screen.getByText(alerts[1].personName!).getAttribute("href")).toBe(
       `/person/${alerts[1].personId}`,
     );
     expect(screen.getAllByText(alerts[0].description).length).toBe(2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,7 +1466,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#593532c3ba219773dc45a27e9f503435bbce39cb"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#93ba7f1c90b576dae93b49ae7d9cca9ecf3e6048"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"


### PR DESCRIPTION
Copy of PR #56 which failed to deploy to development potentially because the 'common' commit hash reference it was using was not the latest. 

https://app.circleci.com/pipelines/github/LBHackney-IT/mtfh-frontend-property/297/workflows/fd45e188-b11a-44ce-ac7b-04a94d70e7c6/jobs/1021

PR #56 description:
If you run all MMH MFEs, 'main' branch if each one, 'property' should throw the below error.

There is an issue with the `alerts` object that's being passed into the component CautionaryAlertsDetails, in `cautionary-alerts-details.test.tsx`

![image](https://user-images.githubusercontent.com/70756861/230139559-4bbcc621-d92e-4e26-9616-54c1b7bf9712.png)

NOTE: after checking with Adam T, the `skip` keyword is to be left there for the two tests for the time being, as team powerhouse is working on a cautionary alert related fix.

The 'base' alert used now implements the Alert interface (from 'common') and I've added exclamation marks so that TS stops worrying about alerts[x].personName being potentially null. 
