### PR TITLE
reverted CA changes so you can see CA Alert from API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ jobs:
                 command: |
                     export APP_ENV=<<parameters.stage>>
                     export APP_CDN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/property-app-url --query Parameter.Value --output text)
-                    export CAUTIONARY_ALERT_SPREADSHEET=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cautionary-alert-spreadsheet --query Parameter.Value --output text)
                     yarn build
             - run:
                   name: Deploy to S3
@@ -155,7 +154,6 @@ jobs:
                 command: |
                     export APP_ENV=<<parameters.stage>>
                     export APP_CDN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/property-app-url --query Parameter.Value --output text)
-                    export CAUTIONARY_ALERT_SPREADSHEET=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cautionary-alert-spreadsheet --query Parameter.Value --output text)
                     yarn build
             - run:
                   name: Deploy to S3
@@ -178,7 +176,6 @@ jobs:
                 command: |
                     export APP_ENV=<<parameters.stage>>
                     export APP_CDN=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/property-app-url --query Parameter.Value --output text)
-                    export CAUTIONARY_ALERT_SPREADSHEET=$(aws ssm get-parameter --name /housing-tl/<<parameters.stage>>/cautionary-alert-spreadsheet --query Parameter.Value --output text)
                     yarn build
             - run:
                   name: Deploy to S3

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,5 +15,13 @@ module.exports = {
   testPathIgnorePatterns: ["test-utils.ts"],
   coverageDirectory: "../coverage",
   coveragePathIgnorePatterns: ["mocks", "test-utils.ts"],
+  coverageThreshold: {
+    global: {
+      statements: 70,
+      branches: 70,
+      functions: 70,
+      lines: 70,
+    },
+  },
   testEnvironment: "jsdom",
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,13 +15,5 @@ module.exports = {
   testPathIgnorePatterns: ["test-utils.ts"],
   coverageDirectory: "../coverage",
   coveragePathIgnorePatterns: ["mocks", "test-utils.ts"],
-  coverageThreshold: {
-    global: {
-      statements: 60,
-      branches: 60,
-      functions: 60,
-      lines: 60,
-    },
-  },
   testEnvironment: "jsdom",
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,10 +17,10 @@ module.exports = {
   coveragePathIgnorePatterns: ["mocks", "test-utils.ts"],
   coverageThreshold: {
     global: {
-      statements: 70,
-      branches: 70,
-      functions: 70,
-      lines: 70,
+      statements: 60,
+      branches: 60,
+      functions: 60,
+      lines: 60,
     },
   },
   testEnvironment: "jsdom",

--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
@@ -20,7 +20,7 @@ const alert: Alert = {
   personName: "Joan Fisher",
   personId: "1",
   reason: "",
-  startDate: ""
+  startDate: "",
 };
 
 describe("CautionaryAlertsDetails", () => {

--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.test.tsx
@@ -11,7 +11,6 @@ import { Alert } from "@mtfh/common/lib/api/cautionary-alerts/v1/types";
 const { cautionaryAlerts } = locale;
 
 const alert: Alert = {
-  alertId: "1234",
   alertCode: "VA",
   assureReference: "",
   dateModified: "",
@@ -21,8 +20,7 @@ const alert: Alert = {
   personName: "Joan Fisher",
   personId: "1",
   reason: "",
-  startDate: "",
-  isActive: true,
+  startDate: ""
 };
 
 describe("CautionaryAlertsDetails", () => {
@@ -32,7 +30,7 @@ describe("CautionaryAlertsDetails", () => {
     expect(screen.getByText(cautionaryAlerts.none)).toBeInTheDocument();
   });
 
-  it.skip("should display cautionary alerts - 1 alert per person", () => {
+  it("should display cautionary alerts - 1 alert per person", () => {
     const alerts = [
       alert,
       {
@@ -53,7 +51,7 @@ describe("CautionaryAlertsDetails", () => {
     expect(screen.getAllByText(alerts[0].description).length).toBe(2);
   });
 
-  it.skip("should display cautionary alerts - 2 alerts per person", () => {
+  it("should display cautionary alerts - 2 alerts per person", () => {
     const alerts = [
       alert,
       {

--- a/src/components/cautionary-alerts-details/cautionary-alerts-details.tsx
+++ b/src/components/cautionary-alerts-details/cautionary-alerts-details.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { locale } from "../../services";
 
 import { Alert } from "@mtfh/common/lib/api/cautionary-alerts/v1/types";
-import { Alert as AlertIcon, Heading, Text } from "@mtfh/common/lib/components";
+import { Alert as AlertIcon, Heading, Link, Text } from "@mtfh/common/lib/components";
 
 import "./cautionary-alerts.styles.scss";
 
@@ -47,13 +47,24 @@ export const CautionaryAlertsDetails = ({ alerts }: { alerts: Alert[] }): JSX.El
       </Heading>
 
       {alerts.length > 0 ? (
-        <Text>
-          Alert(s) found. Check{" "}
-          <a href={process.env.CAUTIONARY_ALERT_SPREADSHEET}>
-            Cautionary Alerts Spreadsheet
-          </a>{" "}
-          for details.
-        </Text>
+        Object.keys(alertsPerPerson).map((personId) => {
+          const { personName, alerts } = alertsPerPerson[personId];
+          return (
+            <Text size="sm" key={personId}>
+              <Link className="person-link" href={`/person/${personId}`}>
+                {personName}
+              </Link>
+              <br />
+              {alerts.map((alert) => {
+                return (
+                  <>
+                    {alert} <br />
+                  </>
+                );
+              })}
+            </Text>
+          );
+        })
       ) : (
         <Text size="sm">{cautionaryAlerts.none}</Text>
       )}

--- a/src/views/asset-view/asset-view.test.tsx
+++ b/src/views/asset-view/asset-view.test.tsx
@@ -207,7 +207,7 @@ test("renders the asset view for invalid asset type", async () => {
   await screen.findByText(locale.assetCouldNotBeLoaded);
 });
 
-it.skip("renders the asset view for missing person id", async () => {
+it("renders the asset view for missing person id", async () => {
   mockActiveTenureV1.householdMembers[0].id = "2d9d6ac5-d376-4ac4-9a00-85659be82d10";
   mockActiveTenureV1.householdMembers[0].fullName = "FAKE_Alice FAKE_Rowe";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
-const {ImportMapWebpackPlugin} = require("@hackney/webpack-import-map-plugin");
+const { ImportMapWebpackPlugin } = require("@hackney/webpack-import-map-plugin");
 const webpack = require("webpack");
 const singleSpaDefaults = require("webpack-config-single-spa-react-ts");
-const {merge} = require("webpack-merge");
+const { merge } = require("webpack-merge");
 
 module.exports = (webpackConfigEnv, argv) => {
     const defaultConfig = singleSpaDefaults({
@@ -41,7 +41,6 @@ module.exports = (webpackConfigEnv, argv) => {
       }),
       new webpack.EnvironmentPlugin({
         APP_ENV: process.env.APP_ENV || "development",
-        CAUTIONARY_ALERT_SPREADSHEET: process.env.CAUTIONARY_ALERT_SPREADSHEET
       }),
     ],
   });


### PR DESCRIPTION
As mentioned in this PR, there was a CA data issue hence we applied a temporary fix to provide the users with the CA spreadsheet. The majority of the data has now been fixed hence we would like to get rid of the temporary fix and show the users the CA from the API like it was before. 