### PR TITLE
Add call to change tenure

### DIFF
--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -8,6 +8,7 @@ import { EditableAddressFormData, editableAddressSchema } from "./schema";
 
 import { Address } from "@mtfh/common/lib/api/address/v1/types";
 import { patchAsset } from "@mtfh/common/lib/api/asset/v1";
+import { EditTenureParams, EditTenuredAssetParams, Tenure, TenureAsset, editTenure, editTenuredAsset, useTenure } from "@mtfh/common/lib/api/tenure/v1";
 import {
   Asset,
   AssetAddress,
@@ -26,6 +27,7 @@ export interface EditableAddressProperties {
   setErrorHeading: (error: string | null) => void;
   setErrorDescription: (error: string | null) => void;
   setCurrentAssetAddress: (assetAddress: AssetAddress) => void;
+  tenureApiObj: Tenure | undefined;
 }
 
 interface PatchAssetFormValues {
@@ -45,6 +47,7 @@ export const EditableAddress = ({
   setErrorHeading,
   setErrorDescription,
   setCurrentAssetAddress,
+  tenureApiObj
 }: EditableAddressProperties): JSX.Element => {
   const [addressEditSuccessful, setAddressEditSuccessful] = useState<boolean>(false);
 
@@ -130,6 +133,31 @@ export const EditableAddress = ({
         setErrorHeading(locale.errors.unableToPatchAsset);
         setErrorDescription(locale.errors.tryAgainOrContactSupport);
       });
+
+      const tenureVersionNumber = tenureApiObj?.etag?.toString()
+        ? tenureApiObj.etag.toString()
+        : "0";
+
+      try {
+        const editTenureReq: EditTenuredAssetParams = {
+          tenuredAsset: {
+            id: assetDetails.id,
+            type: assetDetails.assetType,
+            fullAddress: values.addressLine1 + " " + values.postcode,
+            uprn: assetDetails.assetAddress.uprn,
+            propertyReference: assetDetails.assetId
+          },
+          etag: `${tenureVersionNumber}`,
+          id: "",
+          
+        };
+    
+        await editTenuredAsset(tenureApiObj?.id ?? "", editTenureReq)
+      }
+      catch (err) {
+        console.log(err)
+      }
+
   };
 
   if (!llpgAddress && loading) {

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -8,12 +8,12 @@ import { EditableAddressFormData, editableAddressSchema } from "./schema";
 
 import { Address } from "@mtfh/common/lib/api/address/v1/types";
 import { patchAsset } from "@mtfh/common/lib/api/asset/v1";
-import { EditTenureParams, Tenure, TenureAsset, editTenure, useTenure } from "@mtfh/common/lib/api/tenure/v1";
 import {
   Asset,
   AssetAddress,
   EditAssetAddressRequest,
 } from "@mtfh/common/lib/api/asset/v1/types";
+import { EditTenureParams, Tenure, editTenure } from "@mtfh/common/lib/api/tenure/v1";
 import { Center, Spinner } from "@mtfh/common/lib/components";
 
 import "../styles.scss";
@@ -47,7 +47,7 @@ export const EditableAddress = ({
   setErrorHeading,
   setErrorDescription,
   setCurrentAssetAddress,
-  tenureApiObj
+  tenureApiObj,
 }: EditableAddressProperties): JSX.Element => {
   const [addressEditSuccessful, setAddressEditSuccessful] = useState<boolean>(false);
 
@@ -134,30 +134,27 @@ export const EditableAddress = ({
         setErrorDescription(locale.errors.tryAgainOrContactSupport);
       });
 
-      const tenureVersionNumber = tenureApiObj?.etag?.toString()
-        ? tenureApiObj.etag.toString()
-        : "0";
+    const tenureVersionNumber = tenureApiObj?.etag?.toString()
+      ? tenureApiObj.etag.toString()
+      : "0";
 
-      try {
-        const editTenureReq: EditTenureParams = {
-          tenuredAsset: {
-            id: assetDetails.id,
-            type: assetDetails.assetType,
-            fullAddress: values.addressLine1 + " " + values.postcode,
-            uprn: assetDetails.assetAddress.uprn,
-            propertyReference: assetDetails.assetId
-          },
-          etag: `${tenureVersionNumber}`,
-          id: tenureApiObj?.id ?? "",
-          
-        };
-    
-        await editTenure(editTenureReq)
-      }
-      catch (err) {
-        console.log(err)
-      }
+    try {
+      const request: EditTenureParams = {
+        tenuredAsset: {
+          id: assetDetails.id,
+          type: assetDetails.assetType,
+          fullAddress: `${values.addressLine1} ${values.postcode}`,
+          uprn: assetDetails.assetAddress.uprn,
+          propertyReference: assetDetails.assetId,
+        },
+        etag: `${tenureVersionNumber}`,
+        id: tenureApiObj?.id ?? "",
+      };
 
+      await editTenure(request);
+    } catch (err) {
+      console.log(err);
+    }
   };
 
   if (!llpgAddress && loading) {

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -5,15 +5,18 @@ import { Field, Form, Formik } from "formik";
 
 import { locale } from "../../../services";
 import { EditableAddressFormData, editableAddressSchema } from "./schema";
+import { PatchAssetFormValues } from "./types";
+import {
+  buildAssetAddress,
+  buildEditAssetAddressRequest,
+  buildEditTenureRequest,
+  getAssetVersionNumber,
+} from "./utils";
 
 import { Address } from "@mtfh/common/lib/api/address/v1/types";
 import { patchAsset } from "@mtfh/common/lib/api/asset/v1";
-import {
-  Asset,
-  AssetAddress,
-  EditAssetAddressRequest,
-} from "@mtfh/common/lib/api/asset/v1/types";
-import { EditTenureParams, Tenure, editTenure } from "@mtfh/common/lib/api/tenure/v1";
+import { Asset, AssetAddress } from "@mtfh/common/lib/api/asset/v1/types";
+import { Tenure, editTenure } from "@mtfh/common/lib/api/tenure/v1";
 import { Center, Spinner } from "@mtfh/common/lib/components";
 
 import "../styles.scss";
@@ -27,15 +30,7 @@ export interface EditableAddressProperties {
   setErrorHeading: (error: string | null) => void;
   setErrorDescription: (error: string | null) => void;
   setCurrentAssetAddress: (assetAddress: AssetAddress) => void;
-  tenureApiObj: Tenure | undefined;
-}
-
-interface PatchAssetFormValues {
-  addressLine1: string;
-  addressLine2?: string;
-  addressLine3?: string;
-  addressLine4?: string;
-  postcode: string;
+  tenureApiObject: Tenure | undefined;
 }
 
 export const EditableAddress = ({
@@ -47,7 +42,7 @@ export const EditableAddress = ({
   setErrorHeading,
   setErrorDescription,
   setCurrentAssetAddress,
-  tenureApiObj,
+  tenureApiObject,
 }: EditableAddressProperties): JSX.Element => {
   const [addressEditSuccessful, setAddressEditSuccessful] = useState<boolean>(false);
 
@@ -89,72 +84,42 @@ export const EditableAddress = ({
     );
   };
 
-  const handleSubmit = async (values: PatchAssetFormValues) => {
+  const handleSubmit = async (formValues: PatchAssetFormValues) => {
     setShowSuccess(false);
     setShowError(false);
     setErrorHeading(null);
     setErrorDescription(null);
 
-    const assetAddress: EditAssetAddressRequest = {
-      assetAddress: {
-        uprn: assetDetails.assetAddress.uprn,
-        addressLine1: values.addressLine1,
-        addressLine2: values.addressLine2 ? values.addressLine2 : "",
-        addressLine3: values.addressLine3 ? values.addressLine3 : "",
-        addressLine4: values.addressLine4 ? values.addressLine4 : "",
-        postCode: values.postcode,
-        postPreamble: assetDetails.assetAddress.postPreamble,
-      },
-    };
+    const editAssetAddressRequest = buildEditAssetAddressRequest(
+      formValues,
+      assetDetails,
+    );
+    const assetVersionNumber = getAssetVersionNumber(assetDetails);
+    const editTenureRequest = buildEditTenureRequest(
+      formValues,
+      assetDetails,
+      tenureApiObject,
+    );
 
-    // the toString() prevents a version with a potential valid value of Number 0 from being seen as 'falsy'
-    const assetVersionNumber = assetDetails?.versionNumber?.toString()
-      ? assetDetails.versionNumber.toString()
-      : null;
-
-    await patchAsset(assetDetails.id, assetAddress, assetVersionNumber)
+    await Promise.all([
+      patchAsset(assetDetails.id, editAssetAddressRequest, assetVersionNumber),
+      editTenure(editTenureRequest),
+    ])
       .then(() => {
         // If the update is successful, we update the "Current Address" details (postPreamble and UPRN are unchanged)
-        const newAssetAddress: AssetAddress = {
-          addressLine1: assetAddress.assetAddress.addressLine1,
-          addressLine2: assetAddress.assetAddress.addressLine2,
-          addressLine3: assetAddress.assetAddress.addressLine3,
-          addressLine4: assetAddress.assetAddress.addressLine4,
-          postCode: assetAddress.assetAddress.postCode,
-          postPreamble: assetDetails.assetAddress.postPreamble,
-          uprn: assetDetails.assetAddress.uprn,
-        };
+        const newAssetAddress = buildAssetAddress(editAssetAddressRequest, assetDetails);
+
         setCurrentAssetAddress(newAssetAddress);
         setShowSuccess(true);
         setAddressEditSuccessful(true);
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error(err);
+
         setShowError(true);
         setErrorHeading(locale.errors.unableToPatchAsset);
         setErrorDescription(locale.errors.tryAgainOrContactSupport);
       });
-
-    const tenureVersionNumber = tenureApiObj?.etag?.toString()
-      ? tenureApiObj.etag.toString()
-      : "0";
-
-    try {
-      const request: EditTenureParams = {
-        tenuredAsset: {
-          id: assetDetails.id,
-          type: assetDetails.assetType,
-          fullAddress: `${values.addressLine1} ${values.postcode}`,
-          uprn: assetDetails.assetAddress.uprn,
-          propertyReference: assetDetails.assetId,
-        },
-        etag: `${tenureVersionNumber}`,
-        id: tenureApiObj?.id ?? "",
-      };
-
-      await editTenure(request);
-    } catch (err) {
-      console.log(err);
-    }
   };
 
   if (!llpgAddress && loading) {

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -8,7 +8,7 @@ import { EditableAddressFormData, editableAddressSchema } from "./schema";
 
 import { Address } from "@mtfh/common/lib/api/address/v1/types";
 import { patchAsset } from "@mtfh/common/lib/api/asset/v1";
-import { EditTenureParams, EditTenuredAssetParams, Tenure, TenureAsset, editTenure, editTenuredAsset, useTenure } from "@mtfh/common/lib/api/tenure/v1";
+import { EditTenureParams, Tenure, TenureAsset, editTenure, useTenure } from "@mtfh/common/lib/api/tenure/v1";
 import {
   Asset,
   AssetAddress,
@@ -139,7 +139,7 @@ export const EditableAddress = ({
         : "0";
 
       try {
-        const editTenureReq: EditTenuredAssetParams = {
+        const editTenureReq: EditTenureParams = {
           tenuredAsset: {
             id: assetDetails.id,
             type: assetDetails.assetType,
@@ -148,11 +148,11 @@ export const EditableAddress = ({
             propertyReference: assetDetails.assetId
           },
           etag: `${tenureVersionNumber}`,
-          id: "",
+          id: tenureApiObj?.id ?? "",
           
         };
     
-        await editTenuredAsset(tenureApiObj?.id ?? "", editTenureReq)
+        await editTenure(editTenureReq)
       }
       catch (err) {
         console.log(err)

--- a/src/components/edit-asset-address-form/editable-address/types.ts
+++ b/src/components/edit-asset-address-form/editable-address/types.ts
@@ -1,0 +1,7 @@
+export interface PatchAssetFormValues {
+  addressLine1: string;
+  addressLine2?: string;
+  addressLine3?: string;
+  addressLine4?: string;
+  postcode: string;
+}

--- a/src/components/edit-asset-address-form/editable-address/utils.ts
+++ b/src/components/edit-asset-address-form/editable-address/utils.ts
@@ -1,0 +1,63 @@
+import { PatchAssetFormValues } from "./types";
+
+import {
+  Asset,
+  AssetAddress,
+  EditAssetAddressRequest,
+} from "@mtfh/common/lib/api/asset/v1";
+import { EditTenureParams, Tenure } from "@mtfh/common/lib/api/tenure/v1";
+
+export const getTenureVersionNumber = (tenureApiObj: Tenure | undefined) =>
+  tenureApiObj?.etag?.toString() ? tenureApiObj.etag.toString() : "0";
+
+// the toString() prevents a version with a potential valid value of Number 0 from being seen as 'falsy'
+export const getAssetVersionNumber = (assetDetails: Asset) =>
+  assetDetails?.versionNumber?.toString() ? assetDetails.versionNumber.toString() : null;
+
+export const buildEditAssetAddressRequest = (
+  formValues: PatchAssetFormValues,
+  assetDetails: Asset,
+): EditAssetAddressRequest => ({
+  assetAddress: {
+    uprn: assetDetails.assetAddress.uprn,
+    addressLine1: formValues.addressLine1,
+    addressLine2: formValues.addressLine2 ? formValues.addressLine2 : "",
+    addressLine3: formValues.addressLine3 ? formValues.addressLine3 : "",
+    addressLine4: formValues.addressLine4 ? formValues.addressLine4 : "",
+    postCode: formValues.postcode,
+    postPreamble: assetDetails.assetAddress.postPreamble,
+  },
+});
+
+export const buildEditTenureRequest = (
+  formValues: PatchAssetFormValues,
+  assetDetails: Asset,
+  tenureApiObject: Tenure | undefined,
+): EditTenureParams => {
+  const tenureVersionNumber = getTenureVersionNumber(tenureApiObject);
+
+  return {
+    tenuredAsset: {
+      id: assetDetails.id,
+      type: assetDetails.assetType,
+      fullAddress: `${formValues.addressLine1} ${formValues.postcode}`,
+      uprn: assetDetails.assetAddress.uprn,
+      propertyReference: assetDetails.assetId,
+    },
+    etag: `${tenureVersionNumber}`,
+    id: tenureApiObject?.id ?? "",
+  };
+};
+
+export const buildAssetAddress = (
+  editAssetAddressRequest: EditAssetAddressRequest,
+  assetDetails: Asset,
+): AssetAddress => ({
+  addressLine1: editAssetAddressRequest.assetAddress.addressLine1,
+  addressLine2: editAssetAddressRequest.assetAddress.addressLine2,
+  addressLine3: editAssetAddressRequest.assetAddress.addressLine3,
+  addressLine4: editAssetAddressRequest.assetAddress.addressLine4,
+  postCode: editAssetAddressRequest.assetAddress.postCode,
+  postPreamble: assetDetails.assetAddress.postPreamble,
+  uprn: assetDetails.assetAddress.uprn,
+});

--- a/src/views/asset-edit-view/asset-edit-view.test.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.test.tsx
@@ -225,7 +225,7 @@ test("the current address from the asset is updated using the LLPG address sugge
 
   // The await is required, as it allows the PATCH API call to be intercepted and the Current Asset Address value to be replaced with the LLPG suggestion.
   // Without it, the test may pass but the below expects would not work as expected.
-  
+
   await waitFor(() => {
     userEvent.click(updateButton);
 

--- a/src/views/asset-edit-view/asset-edit-view.test.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.test.tsx
@@ -12,41 +12,41 @@ import { AssetEditView } from ".";
 import * as auth from "@mtfh/common/lib/auth/auth";
 
 const tenureData = {
-  "startOfTenureDate": "2005-07-11T00:00:00",
-  "endOfTenureDate": null,
-  "paymentReference": "7647050047",
-  "tenureType": {
-      "code": "SEC",
-      "description": "Secure"
+  startOfTenureDate: "2005-07-11T00:00:00",
+  endOfTenureDate: null,
+  paymentReference: "7647050047",
+  tenureType: {
+    code: "SEC",
+    description: "Secure",
   },
-  "tenureSource": null,
-  "terminated": {
-      "isTerminated": false,
-      "reasonForTermination": ""
+  tenureSource: null,
+  terminated: {
+    isTerminated: false,
+    reasonForTermination: "",
   },
-  "fundingSource": null,
-  "numberOfAdultsInProperty": 0,
-  "numberOfChildrenInProperty": 0,
-  "hasOffsiteStorage": null,
-  "furtherAccountInformation": null,
-  "legacyReferences": [
-      {
-          "name": "uh_tag_ref",
-          "value": "051956/01"
-      },
-      {
-          "name": "u_saff_tenancy",
-          "value": "01831970"
-      }
+  fundingSource: null,
+  numberOfAdultsInProperty: 0,
+  numberOfChildrenInProperty: 0,
+  hasOffsiteStorage: null,
+  furtherAccountInformation: null,
+  legacyReferences: [
+    {
+      name: "uh_tag_ref",
+      value: "051956/01",
+    },
+    {
+      name: "u_saff_tenancy",
+      value: "01831970",
+    },
   ],
-  "tenuredAsset": {
-      "id": "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
-      "fullAddress": "51 GREENWOOD ROAD - FLAT B",
-      "uprn": "100021045676",
-      "propertyReference": "100021045676",
-      "isTemporaryAccomodation": false
-  }
-}
+  tenuredAsset: {
+    id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
+    fullAddress: "51 GREENWOOD ROAD - FLAT B",
+    uprn: "100021045676",
+    propertyReference: "100021045676",
+    isTemporaryAccomodation: false,
+  },
+};
 
 const assetData = {
   id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",

--- a/src/views/asset-edit-view/asset-edit-view.test.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.test.tsx
@@ -11,6 +11,43 @@ import { AssetEditView } from ".";
 
 import * as auth from "@mtfh/common/lib/auth/auth";
 
+const tenureData = {
+  "startOfTenureDate": "2005-07-11T00:00:00",
+  "endOfTenureDate": null,
+  "paymentReference": "7647050047",
+  "tenureType": {
+      "code": "SEC",
+      "description": "Secure"
+  },
+  "tenureSource": null,
+  "terminated": {
+      "isTerminated": false,
+      "reasonForTermination": ""
+  },
+  "fundingSource": null,
+  "numberOfAdultsInProperty": 0,
+  "numberOfChildrenInProperty": 0,
+  "hasOffsiteStorage": null,
+  "furtherAccountInformation": null,
+  "legacyReferences": [
+      {
+          "name": "uh_tag_ref",
+          "value": "051956/01"
+      },
+      {
+          "name": "u_saff_tenancy",
+          "value": "01831970"
+      }
+  ],
+  "tenuredAsset": {
+      "id": "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
+      "fullAddress": "51 GREENWOOD ROAD - FLAT B",
+      "uprn": "100021045676",
+      "propertyReference": "100021045676",
+      "isTemporaryAccomodation": false
+  }
+}
+
 const assetData = {
   id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
   assetId: "100021045676",
@@ -83,6 +120,12 @@ beforeEach(() => {
   jest.resetAllMocks();
 
   jest.spyOn(auth, "isAuthorisedForGroups").mockReturnValue(true);
+
+  server.use(
+    rest.get("/api/v1/tenures/:id", (req, res, ctx) => {
+      return res(ctx.json(tenureData));
+    }),
+  );
 
   server.use(
     rest.get("/api/v1/assets/:id", (req, res, ctx) => {

--- a/src/views/asset-edit-view/asset-edit-view.test.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.test.tsx
@@ -12,6 +12,7 @@ import { AssetEditView } from ".";
 import * as auth from "@mtfh/common/lib/auth/auth";
 
 const tenureData = {
+  id: "387ddd25-5b10-452d-ba44-1cfac0583075",
   startOfTenureDate: "2005-07-11T00:00:00",
   endOfTenureDate: null,
   paymentReference: "7647050047",
@@ -82,7 +83,11 @@ const assetData = {
     readyToLetDate: false,
   },
   assetCharacteristics: null,
-  tenure: null,
+  tenure: {
+    id: "387ddd25-5b10-452d-ba44-1cfac0583075",
+    type: "Asylum Seeker",
+    startOfTenureDate: "2011-01-01T00:00:00Z",
+  },
   versionNumber: 18,
   patches: [
     {
@@ -141,6 +146,12 @@ beforeEach(() => {
 
   server.use(
     rest.patch(`/api/v1/assets/${assetData.id}/address`, (req, res, ctx) => {
+      return res(ctx.status(204));
+    }),
+  );
+
+  server.use(
+    rest.patch(`/api/v1/tenures/:id`, (req, res, ctx) => {
       return res(ctx.status(204));
     }),
   );
@@ -214,6 +225,7 @@ test("the current address from the asset is updated using the LLPG address sugge
 
   // The await is required, as it allows the PATCH API call to be intercepted and the Current Asset Address value to be replaced with the LLPG suggestion.
   // Without it, the test may pass but the below expects would not work as expected.
+  
   await waitFor(() => {
     userEvent.click(updateButton);
 

--- a/src/views/asset-edit-view/asset-edit-view.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.tsx
@@ -6,13 +6,18 @@ import { assetAdminAuthGroups } from "../../services/config/config";
 import { AssetEditLayout } from "./layout";
 
 import { useAsset } from "@mtfh/common/lib/api/asset/v1";
+import { Tenure, useTenure } from "@mtfh/common/lib/api/tenure/v1";
+
 import { isAuthorisedForGroups } from "@mtfh/common/lib/auth";
 import { Center, ErrorSummary, Spinner } from "@mtfh/common/lib/components";
+import { assetHasFloors } from "utils/asset-type";
 
 export const AssetEditView = (): JSX.Element => {
   const { assetId } = useParams<{ assetId: string }>();
 
   const { data: asset, ...assetRequest } = useAsset(assetId);
+
+  const tenure = useTenure(asset?.tenure ? asset?.tenure.id : null).data;
 
   if (assetRequest.error) {
     return (
@@ -44,7 +49,7 @@ export const AssetEditView = (): JSX.Element => {
   return (
     <>
       {asset.assetType === "Dwelling" || asset.assetType === "LettableNonDwelling" ? (
-        <AssetEditLayout assetDetails={asset} />
+        <AssetEditLayout assetDetails={asset} tenureApiObject={tenure} />
       ) : (
         <h1>{locale.assetCouldNotBeLoaded}</h1>
       )}

--- a/src/views/asset-edit-view/asset-edit-view.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.tsx
@@ -6,11 +6,9 @@ import { assetAdminAuthGroups } from "../../services/config/config";
 import { AssetEditLayout } from "./layout";
 
 import { useAsset } from "@mtfh/common/lib/api/asset/v1";
-import { Tenure, useTenure } from "@mtfh/common/lib/api/tenure/v1";
-
+import { useTenure } from "@mtfh/common/lib/api/tenure/v1";
 import { isAuthorisedForGroups } from "@mtfh/common/lib/auth";
 import { Center, ErrorSummary, Spinner } from "@mtfh/common/lib/components";
-import { assetHasFloors } from "utils/asset-type";
 
 export const AssetEditView = (): JSX.Element => {
   const { assetId } = useParams<{ assetId: string }>();

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -86,7 +86,7 @@ export const AssetEditLayout = ({
             setErrorHeading={setErrorHeading}
             setErrorDescription={setErrorDescription}
             setShowSuccess={setShowSuccess}
-            tenureApiObj={tenureApiObject}
+            tenureApiObject={tenureApiObject}
           />
         </section>
         <section>

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -10,13 +10,16 @@ import { Asset, AssetAddress } from "@mtfh/common/lib/api/asset/v1";
 import { ErrorSummary, Link, StatusBox } from "@mtfh/common/lib/components";
 
 import "./styles.scss";
+import { Tenure } from "@mtfh/common/lib/api/tenure/v1";
 
 export interface AssetEditLayoutProperties {
   assetDetails: Asset;
+  tenureApiObject: Tenure | undefined;
 }
 
 export const AssetEditLayout = ({
   assetDetails,
+  tenureApiObject
 }: AssetEditLayoutProperties): JSX.Element => {
   const [currentAssetAddress, setCurrentAssetAddress] = useState<AssetAddress>(
     assetDetails.assetAddress,
@@ -83,6 +86,7 @@ export const AssetEditLayout = ({
             setErrorHeading={setErrorHeading}
             setErrorDescription={setErrorDescription}
             setShowSuccess={setShowSuccess}
+            tenureApiObj={tenureApiObject}
           />
         </section>
         <section>

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -7,10 +7,10 @@ import { locale } from "../../services";
 
 import { Address, getAddressViaUprn } from "@mtfh/common/lib/api/address/v1";
 import { Asset, AssetAddress } from "@mtfh/common/lib/api/asset/v1";
+import { Tenure } from "@mtfh/common/lib/api/tenure/v1";
 import { ErrorSummary, Link, StatusBox } from "@mtfh/common/lib/components";
 
 import "./styles.scss";
-import { Tenure } from "@mtfh/common/lib/api/tenure/v1";
 
 export interface AssetEditLayoutProperties {
   assetDetails: Asset;
@@ -19,7 +19,7 @@ export interface AssetEditLayoutProperties {
 
 export const AssetEditLayout = ({
   assetDetails,
-  tenureApiObject
+  tenureApiObject,
 }: AssetEditLayoutProperties): JSX.Element => {
   const [currentAssetAddress, setCurrentAssetAddress] = useState<AssetAddress>(
     assetDetails.assetAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,12 +177,19 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.18.6":
+"@babel/helper-module-imports@^7.16.7":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.21.4":
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz#ac88b2f76093637489e718a90cec6cf8a9b029af"
+  integrity sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==
+  dependencies:
+    "@babel/types" "^7.21.4"
 
 "@babel/helper-module-transforms@^7.14.5", "@babel/helper-module-transforms@^7.14.8":
   version "7.14.8"
@@ -215,10 +222,15 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
   integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
-"@babel/helper-plugin-utils@^7.16.7", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.19.0":
+"@babel/helper-plugin-utils@^7.16.7":
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
   integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
+
+"@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.19.0", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz#345f2377d05a720a4e5ecfa39cbf4474a4daed56"
+  integrity sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==
 
 "@babel/helper-remap-async-to-generator@^7.14.5":
   version "7.14.5"
@@ -260,10 +272,10 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-string-parser@^7.19.4":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
-  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+"@babel/helper-string-parser@^7.19.4", "@babel/helper-string-parser@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
+  integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
 
 "@babel/helper-validator-identifier@^7.14.5":
   version "7.14.8"
@@ -286,9 +298,9 @@
   integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
 
 "@babel/helper-validator-option@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
-  integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz#8224c7e13ace4bafdc4004da2cf064ef42673180"
+  integrity sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==
 
 "@babel/helper-wrap-function@^7.14.5":
   version "7.14.5"
@@ -516,12 +528,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.16.7", "@babel/plugin-syntax-jsx@^7.18.6":
+"@babel/plugin-syntax-jsx@^7.16.7":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
   integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
+
+"@babel/plugin-syntax-jsx@^7.18.6", "@babel/plugin-syntax-jsx@^7.21.4":
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.21.4.tgz#f264ed7bf40ffc9ec239edabc17a50c4f5b6fea2"
+  integrity sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.20.2"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4", "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
@@ -808,7 +827,7 @@
     "@babel/plugin-syntax-jsx" "^7.16.7"
     "@babel/types" "^7.17.0"
 
-"@babel/plugin-transform-react-jsx@^7.16.7", "@babel/plugin-transform-react-jsx@^7.18.6":
+"@babel/plugin-transform-react-jsx@^7.16.7":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz#b3cbb7c3a00b92ec8ae1027910e331ba5c500eb9"
   integrity sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==
@@ -818,6 +837,17 @@
     "@babel/helper-plugin-utils" "^7.19.0"
     "@babel/plugin-syntax-jsx" "^7.18.6"
     "@babel/types" "^7.19.0"
+
+"@babel/plugin-transform-react-jsx@^7.18.6":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.5.tgz#bd98f3b429688243e4fa131fe1cbb2ef31ce6f38"
+  integrity sha512-ELdlq61FpoEkHO6gFRpfj0kUgSwQTGoaEU8eMRoS8Dv3v6e7BjEAj5WMtIBRdHUeAioMhKP5HyxNzNnP+heKbA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-module-imports" "^7.21.4"
+    "@babel/helper-plugin-utils" "^7.21.5"
+    "@babel/plugin-syntax-jsx" "^7.21.4"
+    "@babel/types" "^7.21.5"
 
 "@babel/plugin-transform-react-pure-annotations@^7.14.5":
   version "7.16.7"
@@ -1052,10 +1082,10 @@
     core-js-pure "^3.15.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13":
-  version "7.20.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.6.tgz#facf4879bfed9b5326326273a64220f099b0fce3"
-  integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.21.0":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
+  integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
   dependencies:
     regenerator-runtime "^0.13.11"
 
@@ -1129,12 +1159,12 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.18.6", "@babel/types@^7.19.0":
-  version "7.20.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.5.tgz#e206ae370b5393d94dfd1d04cd687cace53efa84"
-  integrity sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==
+"@babel/types@^7.18.6", "@babel/types@^7.19.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.5.tgz#18dfbd47c39d3904d5db3d3dc2cc80bedb60e5b6"
+  integrity sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==
   dependencies:
-    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-string-parser" "^7.21.5"
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
@@ -1473,7 +1503,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#6f46034b54803e38d3c3043b7499254d1eb5752c"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#b22720a8da2620c8a4e770bfca125aaca3a38bb8"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"
@@ -1747,9 +1777,9 @@
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
 "@types/deep-diff@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/deep-diff/-/deep-diff-1.0.1.tgz#eae15119c68b72b541731872a2883da89dc39396"
-  integrity sha512-cZIq2GFcPmW0/M7dtLuphyoU8f3zpTcBgV+wkFFJ0CK0lwRVGGLaBSJZ98qs4LjtLimPq1Bb2VJnhGn6SEE4IA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-diff/-/deep-diff-1.0.2.tgz#36f1291f0aead8aceb847cde6f07ae613a78ac4f"
+  integrity sha512-WD2O611C7Oz7RSwKbSls8LaznKfWfXh39CHY9Amd8FhQz+NJRe20nUHhYpOopVq9M2oqDZd4L6AzqJIXQycxiA==
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
@@ -1872,9 +1902,9 @@
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*":
-  version "18.11.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.10.tgz#4c64759f3c2343b7e6c4b9caf761c7a3a05cee34"
-  integrity sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==
+  version "20.1.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.7.tgz#ce10c802f7731909d0a44ac9888e8b3a9125eb62"
+  integrity sha512-WCuw/o4GSwDGMoonES8rcvwsig77dGCMbZDrZr2x4ZZiNW4P/gcoZXe/0twgtobcTkmg9TuKflxYL/DuwDyJzg==
 
 "@types/node@^16.7.1":
   version "16.11.7"
@@ -2000,9 +2030,9 @@
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
 
 "@types/yargs@^15.0.0":
-  version "15.0.14"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
-  integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  version "15.0.15"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.15.tgz#e609a2b1ef9e05d90489c2f5f45bbfb2be092158"
+  integrity sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3434,9 +3464,11 @@ date-fns@2.23.0, date-fns@^2.16.1:
   integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
 
 date-fns@^2.23.0:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 date-fns@^2.24.0:
   version "2.24.0"
@@ -3474,12 +3506,7 @@ decimal.js@^10.2.1:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
-decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==
-
-decode-uri-component@^0.2.2:
+decode-uri-component@^0.2.0, decode-uri-component@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
@@ -4497,10 +4524,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
-focus-lock@^0.11.2:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.4.tgz#fbf84894d7c384f25a2c7cf5d97c848131d97f6f"
-  integrity sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==
+focus-lock@^0.11.6:
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.6.tgz#e8821e21d218f03e100f7dc27b733f9c4f61e683"
+  integrity sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==
   dependencies:
     tslib "^2.0.3"
 
@@ -7312,22 +7339,12 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-query-string@^7.0.0:
+query-string@^7.0.0, query-string@^7.0.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
   integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
   dependencies:
     decode-uri-component "^0.2.2"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
-query-string@^7.0.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
-  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
-  dependencies:
-    decode-uri-component "^0.2.0"
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
@@ -7386,12 +7403,12 @@ react-fast-compare@^2.0.1:
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
 react-focus-lock@^2.5.1:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.2.tgz#a57dfd7c493e5a030d87f161c96ffd082bd920f2"
-  integrity sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.4.tgz#4753f6dcd167c39050c9d84f9c63c71b3ff8462e"
+  integrity sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.11.2"
+    focus-lock "^0.11.6"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.6"
     use-callback-ref "^1.3.0"
@@ -7412,7 +7429,7 @@ react-merge-refs@^1.1.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-remove-scroll-bar@^2.3.3:
+react-remove-scroll-bar@^2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
   integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
@@ -7421,11 +7438,11 @@ react-remove-scroll-bar@^2.3.3:
     tslib "^2.0.0"
 
 react-remove-scroll@^2.4.2:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
-  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz#7510b8079e9c7eebe00e65a33daaa3aa29a10336"
+  integrity sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==
   dependencies:
-    react-remove-scroll-bar "^2.3.3"
+    react-remove-scroll-bar "^2.3.4"
     react-style-singleton "^2.2.1"
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
@@ -7787,9 +7804,9 @@ rxjs@^6.4.0, rxjs@^6.6.3:
     tslib "^1.9.0"
 
 rxjs@^7.0.1:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
-  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
   dependencies:
     tslib "^2.1.0"
 
@@ -8700,9 +8717,9 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslib@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary of Changes

- There is a sub-object in Tenure which contains information about the tenured asset
- This needs to be updated when the Asset is updated
- Add call to retrieve Tenure (necessary to find ETAG)
- Add call to update Tenure

## Additional Changes
- Added `utils.ts` file to break up code
- Added `types.ts` file to enable reuse of `PatchAssetFormValues`
- Moved both patch requests into `Promise.All()` block to reuse success and error logic