### PR TITLE
Add Asset - New post preamble optional field & existing area office name field changed from string input to dropdown

### DIFF
--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -298,6 +298,15 @@ export const NewAsset = ({
                 className="govuk-input lbh-input"
                 data-testid="uprn"
               />
+              <label className="govuk-label lbh-label" htmlFor="post-preamble">
+                Post preamble
+              </label>
+              <Field
+                id="post-preamble"
+                name="postPreamble"
+                className="govuk-input lbh-input"
+                data-testid="post-preamble"
+              />
               <div
                 className={
                   errors.addressLine1 && touched.addressLine1
@@ -390,15 +399,6 @@ export const NewAsset = ({
                   data-testid="postcode"
                 />
               </div>
-              <label className="govuk-label lbh-label" htmlFor="post-preamble">
-                Post preamble
-              </label>
-              <Field
-                id="post-preamble"
-                name="postPreamble"
-                className="govuk-input lbh-input"
-                data-testid="post-preamble"
-              />
               <h2 className="lbh-heading-h2">Property management</h2>
               <label className="govuk-label lbh-label" htmlFor="agent">
                 Agent

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -15,12 +15,12 @@ import {
 } from "../../utils/asset-type";
 import { InlineAssetSearch } from "../inline-asset-search";
 import { NewPropertyFormData, newPropertySchema } from "./schema";
+import { renderAreaOfficeNames } from "./utils/area-office-names";
+import { renderManagingOrganisationOptions } from "./utils/managing-organisations";
 
 import { Center, Spinner } from "@mtfh/common";
 import { createAsset } from "@mtfh/common/lib/api/asset/v1";
 import { CreateNewAssetRequest } from "@mtfh/common/lib/api/asset/v1/types";
-import { renderManagingOrganisationOptions } from "./utils/managing-organisations";
-import { renderAreaOfficeNames } from "./utils/area-office-names";
 
 export interface Props {
   setShowSuccess: (value: boolean) => void;
@@ -721,7 +721,7 @@ export const NewAsset = ({
                   data-module="govuk-button"
                   type="submit"
                   id="submit-new-property-button"
-                // disabled={!submitEditEnabled}
+                  // disabled={!submitEditEnabled}
                 >
                   Create new property
                 </button>

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -111,6 +111,7 @@ export const NewAsset = ({
           addressLine3: "",
           addressLine4: "",
           postcode: "",
+          postPreamble: "",
           agent: "",
           areaOfficeName: "",
           isCouncilProperty: "",
@@ -389,6 +390,15 @@ export const NewAsset = ({
                   data-testid="postcode"
                 />
               </div>
+              <label className="govuk-label lbh-label" htmlFor="post-preamble">
+                Post preamble
+              </label>
+              <Field
+                id="post-preamble"
+                name="postPreamble"
+                className="govuk-input lbh-input"
+                data-testid="post-preamble"
+              />
               <h2 className="lbh-heading-h2">Property management</h2>
               <label className="govuk-label lbh-label" htmlFor="agent">
                 Agent

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../utils/asset-type";
 import { InlineAssetSearch } from "../inline-asset-search";
 import { NewPropertyFormData, newPropertySchema } from "./schema";
-import { renderAreaOfficeNames } from "./utils/area-office-names";
+import { renderAreaOfficeNamesOptions } from "./utils/area-office-names";
 import { renderManagingOrganisationOptions } from "./utils/managing-organisations";
 
 import { Center, Spinner } from "@mtfh/common";
@@ -408,7 +408,7 @@ export const NewAsset = ({
                   {" "}
                   -- Select an option --{" "}
                 </option>
-                {renderAreaOfficeNames()}
+                {renderAreaOfficeNamesOptions()}
               </Field>
               <div
                 className={

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -13,13 +13,14 @@ import {
   assetHasFloors,
   assetIsOfDwellingType,
 } from "../../utils/asset-type";
-import { managingOrganisations } from "../../utils/managing-organisations";
 import { InlineAssetSearch } from "../inline-asset-search";
 import { NewPropertyFormData, newPropertySchema } from "./schema";
 
 import { Center, Spinner } from "@mtfh/common";
 import { createAsset } from "@mtfh/common/lib/api/asset/v1";
 import { CreateNewAssetRequest } from "@mtfh/common/lib/api/asset/v1/types";
+import { renderManagingOrganisationOptions } from "./utils/managing-organisations";
+import { renderAreaOfficeNames } from "./utils/area-office-names";
 
 export interface Props {
   setShowSuccess: (value: boolean) => void;
@@ -42,22 +43,6 @@ export const NewAsset = ({
     return Object.keys(AssetType).map((key, index) => (
       <option key={index} value={key}>
         {key}
-      </option>
-    ));
-  };
-
-  const renderManagingOrganisationOptions = (): JSX.Element[] => {
-    return managingOrganisations.map((org, index) => (
-      <option
-        key={index}
-        value={org.managingOrganisation}
-        defaultValue={
-          org.managingOrganisation === "London Borough of Hackney"
-            ? "London Borough of Hackney"
-            : undefined
-        }
-      >
-        {org.managingOrganisation}
       </option>
     ));
   };
@@ -413,11 +398,18 @@ export const NewAsset = ({
                 Area office name
               </label>
               <Field
+                as="select"
                 id="area-office-name"
                 name="areaOfficeName"
                 className="govuk-input lbh-input"
                 data-testid="area-office-name"
-              />
+              >
+                <option disabled value="">
+                  {" "}
+                  -- Select an option --{" "}
+                </option>
+                {renderAreaOfficeNames()}
+              </Field>
               <div
                 className={
                   errors.isCouncilProperty && touched.isCouncilProperty
@@ -729,7 +721,7 @@ export const NewAsset = ({
                   data-module="govuk-button"
                   type="submit"
                   id="submit-new-property-button"
-                  // disabled={!submitEditEnabled}
+                // disabled={!submitEditEnabled}
                 >
                   Create new property
                 </button>

--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -18,6 +18,7 @@ export const newPropertySchema = () =>
       .typeError("The value must be a valid number"),
     // Address
     uprn: Yup.string(),
+    postPreamble: Yup.string(),
     addressLine1: Yup.string().required("Address line 1 is a required field"),
     addressLine2: Yup.string(),
     addressLine3: Yup.string(),
@@ -27,7 +28,6 @@ export const newPropertySchema = () =>
       .transform(removeWhitespace)
       .required("Postcode is a required field")
       .matches(regexUkPostcode, "Please enter a valid postcode"),
-    postPreamble: Yup.string(),
 
     // Property management
     agent: Yup.string(),

--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -27,6 +27,7 @@ export const newPropertySchema = () =>
       .transform(removeWhitespace)
       .required("Postcode is a required field")
       .matches(regexUkPostcode, "Please enter a valid postcode"),
+    postPreamble: Yup.string(),
 
     // Property management
     agent: Yup.string(),

--- a/src/components/new-asset-form/utils/area-office-names.tsx
+++ b/src/components/new-asset-form/utils/area-office-names.tsx
@@ -93,10 +93,7 @@ const areaOfficeNames = [
 
 const renderAreaOfficeNames = (): JSX.Element[] => {
   return areaOfficeNames.map((office, index) => (
-    <option
-      key={index}
-      value={office.officeName}
-    >
+    <option key={index} value={office.officeName}>
       {`${office.areaOffice} - ${office.officeName}`}
     </option>
   ));

--- a/src/components/new-asset-form/utils/area-office-names.tsx
+++ b/src/components/new-asset-form/utils/area-office-names.tsx
@@ -91,7 +91,7 @@ const areaOfficeNames = [
   },
 ];
 
-const renderAreaOfficeNames = (): JSX.Element[] => {
+const renderAreaOfficeNamesOptions = (): JSX.Element[] => {
   return areaOfficeNames.map((office, index) => (
     <option key={index} value={office.officeName}>
       {`${office.areaOffice} - ${office.officeName}`}
@@ -99,4 +99,4 @@ const renderAreaOfficeNames = (): JSX.Element[] => {
   ));
 };
 
-export { areaOfficeNames, renderAreaOfficeNames };
+export { areaOfficeNames, renderAreaOfficeNamesOptions };

--- a/src/components/new-asset-form/utils/area-office-names.tsx
+++ b/src/components/new-asset-form/utils/area-office-names.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+
+const areaOfficeNames = [
+  {
+    areaOffice: "AN",
+    officeName: "Temp Accommodation (Annexe)",
+  },
+  {
+    areaOffice: "AR",
+    officeName: "Arden Estate TMO (SH)",
+  },
+  {
+    areaOffice: "BB",
+    officeName: "Temp Accommodation (Bed & Breakfast)",
+  },
+  {
+    areaOffice: "CL",
+    officeName: "Clapton Park TMO (HN)",
+  },
+  {
+    areaOffice: "CR",
+    officeName: "Cranston Estate TMO (SH)",
+  },
+  {
+    areaOffice: "CT",
+    officeName: "Clapton Panel Area Team",
+  },
+  {
+    areaOffice: "DO",
+    officeName: "Downs TMO (SN)",
+  },
+  {
+    areaOffice: "HL",
+    officeName: "Temp Accommodation (Hostels)",
+  },
+  {
+    areaOffice: "HN",
+    officeName: "Homerton (1) Panel Area Team",
+  },
+  {
+    areaOffice: "HT",
+    officeName: "Homerton (2) Panel Area Team",
+  },
+  {
+    areaOffice: "LO",
+    officeName: "Lordship South TMO (SN)",
+  },
+  {
+    areaOffice: "NE",
+    officeName: "Stamford Hill Panel Area Team",
+  },
+  {
+    areaOffice: "PL",
+    officeName: "Temp Accommodation (Private Lease)",
+  },
+  {
+    areaOffice: "QB",
+    officeName: "Central Panel Area Team",
+  },
+  {
+    areaOffice: "SH",
+    officeName: "Shoreditch Panel Area Team",
+  },
+  {
+    areaOffice: "SN",
+    officeName: "Stoke Newington Panel Area Team",
+  },
+  {
+    areaOffice: "SU",
+    officeName: "Suffolk Estate TMO (CE)",
+  },
+  {
+    areaOffice: "TO",
+    officeName: "Tower TMO (CE)",
+  },
+  {
+    areaOffice: "TR",
+    officeName: "Travellers sites",
+  },
+  {
+    areaOffice: "WE",
+    officeName: "Wenlock Barn TMO (SH)",
+  },
+  {
+    areaOffice: "WI",
+    officeName: "Wick Village TMO (HN)",
+  },
+  {
+    areaOffice: "WY",
+    officeName: "Wyke TMO (HN)",
+  },
+];
+
+const renderAreaOfficeNames = (): JSX.Element[] => {
+  return areaOfficeNames.map((office, index) => (
+    <option
+      key={index}
+      value={office.officeName}
+    >
+      {`${office.areaOffice} - ${office.officeName}`}
+    </option>
+  ));
+};
+
+export { areaOfficeNames, renderAreaOfficeNames };

--- a/src/components/new-asset-form/utils/managing-organisations.tsx
+++ b/src/components/new-asset-form/utils/managing-organisations.tsx
@@ -51,4 +51,4 @@ const renderManagingOrganisationOptions = (): JSX.Element[] => {
   ));
 };
 
-export {managingOrganisations, renderManagingOrganisationOptions};
+export { managingOrganisations, renderManagingOrganisationOptions };

--- a/src/components/new-asset-form/utils/managing-organisations.tsx
+++ b/src/components/new-asset-form/utils/managing-organisations.tsx
@@ -1,4 +1,6 @@
-export const managingOrganisations = [
+import React from "react";
+
+const managingOrganisations = [
   {
     managingOrganisation: "London Borough of Hackney",
     managingOrganisationId: "c01e3146-e630-c2cd-e709-18ef57bf3724",
@@ -32,3 +34,21 @@ export const managingOrganisations = [
     managingOrganisationId: "e2098c9a-2186-13e9-b9e0-21c3976a0373",
   },
 ];
+
+const renderManagingOrganisationOptions = (): JSX.Element[] => {
+  return managingOrganisations.map((org, index) => (
+    <option
+      key={index}
+      value={org.managingOrganisation}
+      defaultValue={
+        org.managingOrganisation === "London Borough of Hackney"
+          ? "London Borough of Hackney"
+          : undefined
+      }
+    >
+      {org.managingOrganisation}
+    </option>
+  ));
+};
+
+export {managingOrganisations, renderManagingOrganisationOptions};

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 
 import { NewPropertyFormData } from "../components/new-asset-form/schema";
-import { managingOrganisations } from "../utils/managing-organisations";
+import { managingOrganisations } from "../components/new-asset-form/utils/managing-organisations";
 
 import { CreateNewAssetRequest } from "@mtfh/common/lib/api/asset/v1";
 

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -21,6 +21,7 @@ export const assetToCreateAssetAddressRequest = (values: NewPropertyFormData) =>
     },
     assetAddress: {
       uprn: values?.uprn ?? "",
+      postPreamble: values?.postPreamble ?? "",
       addressLine1: values.addressLine1,
       addressLine2: values?.addressLine2 ?? "",
       addressLine3: values?.addressLine3 ?? "",

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -43,6 +43,7 @@ export const assetToCreateAssetAddressRequest = (values: NewPropertyFormData) =>
       windowType: values?.windowType ?? "",
       numberOfLifts: values?.numberOfLifts ?? null,
     },
+    patches: undefined,
   };
 
   return asset;

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -345,6 +345,19 @@ exports[`renders the whole 'New asset form' view 1`] = `
           name="uprn"
           value=""
         />
+        <label
+          class="govuk-label lbh-label"
+          for="post-preamble"
+        >
+          Post preamble
+        </label>
+        <input
+          class="govuk-input lbh-input"
+          data-testid="post-preamble"
+          id="post-preamble"
+          name="postPreamble"
+          value=""
+        />
         <div
           class="govuk-form-group lbh-form-group"
         >
@@ -467,13 +480,129 @@ exports[`renders the whole 'New asset form' view 1`] = `
         >
           Area office name
         </label>
-        <input
+        <select
           class="govuk-input lbh-input"
           data-testid="area-office-name"
           id="area-office-name"
           name="areaOfficeName"
-          value=""
-        />
+        >
+          <option
+            disabled=""
+            value=""
+          >
+             -- Select an option -- 
+          </option>
+          <option
+            value="Temp Accommodation (Annexe)"
+          >
+            AN - Temp Accommodation (Annexe)
+          </option>
+          <option
+            value="Arden Estate TMO (SH)"
+          >
+            AR - Arden Estate TMO (SH)
+          </option>
+          <option
+            value="Temp Accommodation (Bed & Breakfast)"
+          >
+            BB - Temp Accommodation (Bed & Breakfast)
+          </option>
+          <option
+            value="Clapton Park TMO (HN)"
+          >
+            CL - Clapton Park TMO (HN)
+          </option>
+          <option
+            value="Cranston Estate TMO (SH)"
+          >
+            CR - Cranston Estate TMO (SH)
+          </option>
+          <option
+            value="Clapton Panel Area Team"
+          >
+            CT - Clapton Panel Area Team
+          </option>
+          <option
+            value="Downs TMO (SN)"
+          >
+            DO - Downs TMO (SN)
+          </option>
+          <option
+            value="Temp Accommodation (Hostels)"
+          >
+            HL - Temp Accommodation (Hostels)
+          </option>
+          <option
+            value="Homerton (1) Panel Area Team"
+          >
+            HN - Homerton (1) Panel Area Team
+          </option>
+          <option
+            value="Homerton (2) Panel Area Team"
+          >
+            HT - Homerton (2) Panel Area Team
+          </option>
+          <option
+            value="Lordship South TMO (SN)"
+          >
+            LO - Lordship South TMO (SN)
+          </option>
+          <option
+            value="Stamford Hill Panel Area Team"
+          >
+            NE - Stamford Hill Panel Area Team
+          </option>
+          <option
+            value="Temp Accommodation (Private Lease)"
+          >
+            PL - Temp Accommodation (Private Lease)
+          </option>
+          <option
+            value="Central Panel Area Team"
+          >
+            QB - Central Panel Area Team
+          </option>
+          <option
+            value="Shoreditch Panel Area Team"
+          >
+            SH - Shoreditch Panel Area Team
+          </option>
+          <option
+            value="Stoke Newington Panel Area Team"
+          >
+            SN - Stoke Newington Panel Area Team
+          </option>
+          <option
+            value="Suffolk Estate TMO (CE)"
+          >
+            SU - Suffolk Estate TMO (CE)
+          </option>
+          <option
+            value="Tower TMO (CE)"
+          >
+            TO - Tower TMO (CE)
+          </option>
+          <option
+            value="Travellers sites"
+          >
+            TR - Travellers sites
+          </option>
+          <option
+            value="Wenlock Barn TMO (SH)"
+          >
+            WE - Wenlock Barn TMO (SH)
+          </option>
+          <option
+            value="Wick Village TMO (HN)"
+          >
+            WI - Wick Village TMO (HN)
+          </option>
+          <option
+            value="Wyke TMO (HN)"
+          >
+            WY - Wyke TMO (HN)
+          </option>
+        </select>
         <div
           class="govuk-form-group lbh-form-group"
         >


### PR DESCRIPTION
Added new _Post Preamble_ optional field field in Address section
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/87381fd8-5ca8-43ea-8fac-8f264b7a40e5)

Existing field _Area Office Name_ has been changed from a string field to a drop down field, populated by a set of options. These options come from a [spreadsheet](https://docs.google.com/spreadsheets/d/1sMPVkcKEBUpCS8ALcAQ_IZp8q0RT3eXb/edit#gid=431043573) and they are hardcoded in `area-office-names.tsx`
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/f41c9016-f7f1-4cfe-bee2-5853f66a4211)
