### PR TITLE
Asset hierarchy: Post-testing adjustments

### DIFF
--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -48,9 +48,6 @@ export default {
   repairs: {
     heading: "Repairs",
   },
-  hierarchy: {
-    heading: "Asset hierarchy",
-  },
   tenureDetails: {
     tenureLabel: "Tenure",
     expandedTenureSection: "Tenure details",

--- a/src/views/asset-view/layout.tsx
+++ b/src/views/asset-view/layout.tsx
@@ -94,7 +94,6 @@ const PropertyBody = ({ assetDetails, childAssets }: PropertyBodyProps): JSX.Ele
     <>
       <div id="property-body-grid-container">
         <div id="property-tree-grid-area">
-          <h2 className="lbh-heading-h2">{locale.hierarchy.heading}</h2>
           <PropertyTree asset={assetDetails} childAssets={childAssets} />
         </div>
         <div id="new-process-grid-area">


### PR DESCRIPTION
1. Remove the Asset Hierarchy title - included in this PR
2. Have "grandparent" relationships shown on the tree - these are already shown, however the test data I used for the demo didn't have them included. Specifically, a garage will always be on the same level as the dwelling, it won't be a child of the dwelling