### PR TITLE
MR-698 - New Asset post-feedback changes

### DIFF
--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -124,7 +124,6 @@ export const NewAsset = ({
           assetType: "",
           propertyEstate: "",
           propertyBlock: "",
-          // propertySubBlock: "",
           floorNo: "",
           totalBlockFloors: undefined,
           uprn: "",
@@ -138,7 +137,6 @@ export const NewAsset = ({
           areaOfficeName: "",
           isCouncilProperty: "",
           managingOrganisation: "London Borough of Hackney",
-          isTMOManaged: "",
           patches: patchesState,
           numberOfBedrooms: undefined,
           numberOfLivingRooms: undefined,
@@ -149,7 +147,7 @@ export const NewAsset = ({
         validationSchema={newPropertySchema}
         onSubmit={(values) => handleSubmit(values)}
       >
-        {({ values, errors, touched, handleChange, setFieldValue }) => (
+        {({ values, errors, touched, submitCount, isValid, handleChange, setFieldValue }) => (
           <div id="new-property-form">
             <Form>
               <div
@@ -247,24 +245,6 @@ export const NewAsset = ({
                   value={values.propertyBlock || ""}
                 />
               )}
-              {/* {values.assetType !== "Block" && values.assetType !== "Estate" && (
-                <>
-                  <label className="govuk-label lbh-label" htmlFor="property-sub-block">
-                    Sub-block this property is in
-                  </label>
-                  <Field
-                    id="property-sub-block"
-                    name="propertySubBlock"
-                    className={
-                      errors.propertySubBlock && touched.propertySubBlock
-                        ? "govuk-input lbh-input govuk-input--error"
-                        : "govuk-input lbh-input"
-                    }
-                    type="text"
-                    data-testid="property-sub-block"
-                  />
-                </>
-              )} */}
               {assetHasFloorNo(values.assetType) && (
                 <>
                   <label className="govuk-label lbh-label" htmlFor="floor-no">
@@ -728,6 +708,12 @@ export const NewAsset = ({
                 </Field>
               </div>
               <div className="new-property-form-actions">
+                
+                {!isValid && submitCount > 0 &&
+                <span className="govuk-error-message lbh-error-message">
+                  <span className="govuk-visually-hidden">Error: Check form for errors.</span> Unable to create new property. Please check the form fields for any errors.
+                </span>
+                }
                 <button
                   className="govuk-button lbh-button"
                   data-module="govuk-button"

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -147,7 +147,15 @@ export const NewAsset = ({
         validationSchema={newPropertySchema}
         onSubmit={(values) => handleSubmit(values)}
       >
-        {({ values, errors, touched, submitCount, isValid, handleChange, setFieldValue }) => (
+        {({
+          values,
+          errors,
+          touched,
+          submitCount,
+          isValid,
+          handleChange,
+          setFieldValue,
+        }) => (
           <div id="new-property-form">
             <Form>
               <div
@@ -708,12 +716,15 @@ export const NewAsset = ({
                 </Field>
               </div>
               <div className="new-property-form-actions">
-                
-                {!isValid && submitCount > 0 &&
-                <span className="govuk-error-message lbh-error-message">
-                  <span className="govuk-visually-hidden">Error: Check form for errors.</span> Unable to create new property. Please check the form fields for any errors.
-                </span>
-                }
+                {!isValid && submitCount > 0 && (
+                  <span className="govuk-error-message lbh-error-message">
+                    <span className="govuk-visually-hidden">
+                      Error: Check form for errors.
+                    </span>{" "}
+                    Unable to create new property. Please check the form fields for any
+                    errors.
+                  </span>
+                )}
                 <button
                   className="govuk-button lbh-button"
                   data-module="govuk-button"

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -433,6 +433,168 @@ export const NewAsset = ({
                   data-testid="postcode"
                 />
               </div>
+                            <h2 className="lbh-heading-h2">Asset details</h2>
+              {assetIsOfDwellingType(values.assetType) && (
+                <>
+                  <div
+                    className={
+                      errors.numberOfBedrooms && touched.numberOfBedrooms
+                        ? "govuk-form-group govuk-form-group--error lbh-form-group"
+                        : "govuk-form-group lbh-form-group"
+                    }
+                  >
+                    <label className="govuk-label lbh-label" htmlFor="no-of-bedrooms">
+                      Number of bedrooms
+                    </label>
+                    {errors.numberOfBedrooms && touched.numberOfBedrooms && (
+                      <span
+                        id="no-of-bedrooms-input-error"
+                        className="govuk-error-message lbh-error-message"
+                      >
+                        <span
+                          className="govuk-visually-hidden"
+                          data-testid="error-no-of-bedrooms"
+                        >
+                          Error:
+                        </span>
+                        {errors.numberOfBedrooms}
+                      </span>
+                    )}
+                    <Field
+                      id="no-of-bedrooms"
+                      name="numberOfBedrooms"
+                      className={
+                        errors.numberOfBedrooms && touched.numberOfBedrooms
+                          ? "govuk-input lbh-input govuk-input--error"
+                          : "govuk-input lbh-input"
+                      }
+                      type="text"
+                      data-testid="no-of-bedrooms"
+                    />
+                  </div>
+                  <div
+                    className={
+                      errors.numberOfLivingRooms && touched.numberOfLivingRooms
+                        ? "govuk-form-group govuk-form-group--error lbh-form-group"
+                        : "govuk-form-group lbh-form-group"
+                    }
+                  >
+                    <label className="govuk-label lbh-label" htmlFor="no-of-living-rooms">
+                      Number of living rooms
+                    </label>
+                    {errors.numberOfLivingRooms && touched.numberOfLivingRooms && (
+                      <span
+                        id="no-of-living-rooms-input-error"
+                        className="govuk-error-message lbh-error-message"
+                      >
+                        <span
+                          className="govuk-visually-hidden"
+                          data-testid="error-no-of-living-rooms"
+                        >
+                          Error:
+                        </span>
+                        {errors.numberOfLivingRooms}
+                      </span>
+                    )}
+                    <Field
+                      id="no-of-living-rooms"
+                      name="numberOfLivingRooms"
+                      className={
+                        errors.numberOfLivingRooms && touched.numberOfLivingRooms
+                          ? "govuk-input lbh-input govuk-input--error"
+                          : "govuk-input lbh-input"
+                      }
+                      type="text"
+                      data-testid="no-of-living-rooms"
+                    />
+                  </div>
+                </>
+              )}
+              {assetHasFloors(values.assetType) && (
+                <>
+                  <div
+                    className={
+                      errors.numberOfLifts && touched.numberOfLifts
+                        ? "govuk-form-group govuk-form-group--error lbh-form-group"
+                        : "govuk-form-group lbh-form-group"
+                    }
+                  >
+                    <label className="govuk-label lbh-label" htmlFor="no-of-lifts">
+                      Number of lifts{" "}
+                    </label>
+                    {errors.numberOfLifts && touched.numberOfLifts && (
+                      <span
+                        id="no-of-lifts-input-error"
+                        className="govuk-error-message lbh-error-message"
+                      >
+                        <span
+                          className="govuk-visually-hidden"
+                          data-testid="error-no-of-lifts"
+                        >
+                          Error:
+                        </span>
+                        {errors.numberOfLifts}
+                      </span>
+                    )}
+                    <Field
+                      id="no-of-lifts"
+                      name="numberOfLifts"
+                      className={
+                        errors.numberOfLifts && touched.numberOfLifts
+                          ? "govuk-input lbh-input govuk-input--error"
+                          : "govuk-input lbh-input"
+                      }
+                      type="text"
+                      data-testid="no-of-lifts"
+                    />
+                  </div>
+                </>
+              )}
+              <label className="govuk-label lbh-label" htmlFor="window-type">
+                Window type
+              </label>
+              <Field
+                id="window-type"
+                name="windowType"
+                className="govuk-input lbh-input"
+                data-testid="window-type"
+              />
+              <div
+                className={
+                  errors.yearConstructed && touched.yearConstructed
+                    ? "govuk-form-group govuk-form-group--error lbh-form-group"
+                    : "govuk-form-group lbh-form-group"
+                }
+              >
+                <label className="govuk-label lbh-label" htmlFor="year-constructed">
+                  Year constructed
+                </label>
+                {errors.yearConstructed && touched.yearConstructed && (
+                  <span
+                    id="year-constructed-input-error"
+                    className="govuk-error-message lbh-error-message"
+                  >
+                    <span
+                      className="govuk-visually-hidden"
+                      data-testid="year-constructed"
+                    >
+                      Error:
+                    </span>
+                    {errors.yearConstructed}
+                  </span>
+                )}
+                <Field
+                  id="year-constructed"
+                  name="yearConstructed"
+                  className={
+                    errors.yearConstructed && touched.yearConstructed
+                      ? "govuk-input lbh-input govuk-input--error"
+                      : "govuk-input lbh-input"
+                  }
+                  type="text"
+                  data-testid="year-constructed"
+                />
+              </div>
               <h2 className="lbh-heading-h2">Property management</h2>
               <label className="govuk-label lbh-label" htmlFor="agent">
                 Agent
@@ -624,168 +786,6 @@ export const NewAsset = ({
                 dispatch={dispatch}
                 patchesAndAreasData={patchesAndAreasData}
               />
-              <h2 className="lbh-heading-h2">Asset details</h2>
-              {assetIsOfDwellingType(values.assetType) && (
-                <>
-                  <div
-                    className={
-                      errors.numberOfBedrooms && touched.numberOfBedrooms
-                        ? "govuk-form-group govuk-form-group--error lbh-form-group"
-                        : "govuk-form-group lbh-form-group"
-                    }
-                  >
-                    <label className="govuk-label lbh-label" htmlFor="no-of-bedrooms">
-                      Number of bedrooms
-                    </label>
-                    {errors.numberOfBedrooms && touched.numberOfBedrooms && (
-                      <span
-                        id="no-of-bedrooms-input-error"
-                        className="govuk-error-message lbh-error-message"
-                      >
-                        <span
-                          className="govuk-visually-hidden"
-                          data-testid="error-no-of-bedrooms"
-                        >
-                          Error:
-                        </span>
-                        {errors.numberOfBedrooms}
-                      </span>
-                    )}
-                    <Field
-                      id="no-of-bedrooms"
-                      name="numberOfBedrooms"
-                      className={
-                        errors.numberOfBedrooms && touched.numberOfBedrooms
-                          ? "govuk-input lbh-input govuk-input--error"
-                          : "govuk-input lbh-input"
-                      }
-                      type="text"
-                      data-testid="no-of-bedrooms"
-                    />
-                  </div>
-                  <div
-                    className={
-                      errors.numberOfLivingRooms && touched.numberOfLivingRooms
-                        ? "govuk-form-group govuk-form-group--error lbh-form-group"
-                        : "govuk-form-group lbh-form-group"
-                    }
-                  >
-                    <label className="govuk-label lbh-label" htmlFor="no-of-living-rooms">
-                      Number of living rooms
-                    </label>
-                    {errors.numberOfLivingRooms && touched.numberOfLivingRooms && (
-                      <span
-                        id="no-of-living-rooms-input-error"
-                        className="govuk-error-message lbh-error-message"
-                      >
-                        <span
-                          className="govuk-visually-hidden"
-                          data-testid="error-no-of-living-rooms"
-                        >
-                          Error:
-                        </span>
-                        {errors.numberOfLivingRooms}
-                      </span>
-                    )}
-                    <Field
-                      id="no-of-living-rooms"
-                      name="numberOfLivingRooms"
-                      className={
-                        errors.numberOfLivingRooms && touched.numberOfLivingRooms
-                          ? "govuk-input lbh-input govuk-input--error"
-                          : "govuk-input lbh-input"
-                      }
-                      type="text"
-                      data-testid="no-of-living-rooms"
-                    />
-                  </div>
-                </>
-              )}
-              {assetHasFloors(values.assetType) && (
-                <>
-                  <div
-                    className={
-                      errors.numberOfLifts && touched.numberOfLifts
-                        ? "govuk-form-group govuk-form-group--error lbh-form-group"
-                        : "govuk-form-group lbh-form-group"
-                    }
-                  >
-                    <label className="govuk-label lbh-label" htmlFor="no-of-lifts">
-                      Number of lifts{" "}
-                    </label>
-                    {errors.numberOfLifts && touched.numberOfLifts && (
-                      <span
-                        id="no-of-lifts-input-error"
-                        className="govuk-error-message lbh-error-message"
-                      >
-                        <span
-                          className="govuk-visually-hidden"
-                          data-testid="error-no-of-lifts"
-                        >
-                          Error:
-                        </span>
-                        {errors.numberOfLifts}
-                      </span>
-                    )}
-                    <Field
-                      id="no-of-lifts"
-                      name="numberOfLifts"
-                      className={
-                        errors.numberOfLifts && touched.numberOfLifts
-                          ? "govuk-input lbh-input govuk-input--error"
-                          : "govuk-input lbh-input"
-                      }
-                      type="text"
-                      data-testid="no-of-lifts"
-                    />
-                  </div>
-                </>
-              )}
-              <label className="govuk-label lbh-label" htmlFor="window-type">
-                Window type
-              </label>
-              <Field
-                id="window-type"
-                name="windowType"
-                className="govuk-input lbh-input"
-                data-testid="window-type"
-              />
-              <div
-                className={
-                  errors.yearConstructed && touched.yearConstructed
-                    ? "govuk-form-group govuk-form-group--error lbh-form-group"
-                    : "govuk-form-group lbh-form-group"
-                }
-              >
-                <label className="govuk-label lbh-label" htmlFor="year-constructed">
-                  Year constructed
-                </label>
-                {errors.yearConstructed && touched.yearConstructed && (
-                  <span
-                    id="year-constructed-input-error"
-                    className="govuk-error-message lbh-error-message"
-                  >
-                    <span
-                      className="govuk-visually-hidden"
-                      data-testid="year-constructed"
-                    >
-                      Error:
-                    </span>
-                    {errors.yearConstructed}
-                  </span>
-                )}
-                <Field
-                  id="year-constructed"
-                  name="yearConstructed"
-                  className={
-                    errors.yearConstructed && touched.yearConstructed
-                      ? "govuk-input lbh-input govuk-input--error"
-                      : "govuk-input lbh-input"
-                  }
-                  type="text"
-                  data-testid="year-constructed"
-                />
-              </div>
               <div className="new-property-form-actions">
                 <button
                   className="govuk-button lbh-button"
@@ -795,7 +795,6 @@ export const NewAsset = ({
                 >
                   Create new property
                 </button>
-
                 <RouterLink
                   to="#"
                   className="govuk-button govuk-secondary lbh-button lbh-button--secondary"

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -727,65 +727,6 @@ export const NewAsset = ({
                   {renderManagingOrganisationOptions()}
                 </Field>
               </div>
-              <div
-                className={
-                  errors.isTMOManaged && touched.isTMOManaged
-                    ? "govuk-form-group govuk-form-group--error lbh-form-group"
-                    : "govuk-form-group lbh-form-group"
-                }
-              >
-                <fieldset className="govuk-fieldset">
-                  <legend className="govuk-label lbh-label">Is TMO managed?</legend>
-                  {errors.isTMOManaged && touched.isTMOManaged && (
-                    <span
-                      id="is-tmo-managed-error"
-                      className="govuk-error-message lbh-error-message"
-                    >
-                      <span
-                        className="govuk-visually-hidden"
-                        data-testid="error-is-tmo-managed"
-                      >
-                        Error:
-                      </span>{" "}
-                      {errors.isTMOManaged}
-                    </span>
-                  )}
-                  <div className="govuk-radios lbh-radios">
-                    <div className="govuk-radios__item">
-                      <Field
-                        className="govuk-radios__input"
-                        id="is-tmo-managed-yes"
-                        name="isTMOManaged"
-                        type="radio"
-                        value="Yes"
-                        data-testid="is-tmo-managed-yes"
-                      />
-                      <label
-                        className="govuk-label govuk-radios__label"
-                        htmlFor="is-tmo-managed-yes"
-                      >
-                        Yes
-                      </label>
-                    </div>
-                    <div className="govuk-radios__item">
-                      <Field
-                        className="govuk-radios__input"
-                        id="is-tmo-managed-no"
-                        name="isTMOManaged"
-                        type="radio"
-                        value="No"
-                        data-testid="is-tmo-managed-no"
-                      />
-                      <label
-                        className="govuk-label govuk-radios__label"
-                        htmlFor="is-tmo-managed-no"
-                      >
-                        No
-                      </label>
-                    </div>
-                  </div>
-                </fieldset>
-              </div>
               <div className="new-property-form-actions">
                 <button
                   className="govuk-button lbh-button"

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -433,7 +433,7 @@ export const NewAsset = ({
                   data-testid="postcode"
                 />
               </div>
-                            <h2 className="lbh-heading-h2">Asset details</h2>
+              <h2 className="lbh-heading-h2">Asset details</h2>
               {assetIsOfDwellingType(values.assetType) && (
                 <>
                   <div
@@ -621,6 +621,11 @@ export const NewAsset = ({
                 </option>
                 {renderAreaOfficeNamesOptions()}
               </Field>
+              <PatchesField
+                patchesState={patchesState}
+                dispatch={dispatch}
+                patchesAndAreasData={patchesAndAreasData}
+              />
               <div
                 className={
                   errors.isCouncilProperty && touched.isCouncilProperty
@@ -781,11 +786,6 @@ export const NewAsset = ({
                   </div>
                 </fieldset>
               </div>
-              <PatchesField
-                patchesState={patchesState}
-                dispatch={dispatch}
-                patchesAndAreasData={patchesAndAreasData}
-              />
               <div className="new-property-form-actions">
                 <button
                   className="govuk-button lbh-button"

--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -10,7 +10,6 @@ export const newPropertySchema = () =>
     assetType: Yup.string().required("Asset Type is a required field"),
     propertyEstate: Yup.string(),
     propertyBlock: Yup.string(),
-    // propertySubBlock: Yup.string(),
     floorNo: Yup.string(),
     totalBlockFloors: Yup.number()
       .nullable()
@@ -36,7 +35,6 @@ export const newPropertySchema = () =>
     managingOrganisation: Yup.string().required(
       "Managing organisation is a required field",
     ),
-    isTMOManaged: Yup.string().required("Please select an option"),
     patches: Yup.array()
       .of(
         Yup.object().shape({

--- a/src/components/new-asset-form/styles.scss
+++ b/src/components/new-asset-form/styles.scss
@@ -1,12 +1,6 @@
 @import '~lbh-frontend/lbh/base';
 
-#new-property-form {
 
-    input,
-    select {
-        width: 500px;
-    }
-}
 
 .new-property-form-actions {
 
@@ -16,12 +10,26 @@
     }
 }
 
-#submit-new-property-button {
-    margin-right: 20px;
-}
-
 .patch {
     display: flex;
+}
+
+.patch-remove-link {
+    margin-left: 10px;
+    margin-top: 0px;
+    font-size: 16px !important;
+}
+
+#new-property-form {
+
+    input,
+    select {
+        width: 500px;
+    }
+}
+
+#submit-new-property-button {
+    margin-right: 20px;
 }
 
 #patch-add-link {
@@ -32,8 +40,6 @@
     margin-top: 0;
 }
 
-.patch-remove-link {
-    margin-left: 10px;
-    margin-top: 0px;
-    font-size: 16px !important;
+#new-property-disclaimer {
+    margin-top: 28.5px;
 }

--- a/src/components/new-asset-form/styles.scss
+++ b/src/components/new-asset-form/styles.scss
@@ -28,6 +28,10 @@
     font-size: 16px !important;
 }
 
+#property-patches-container {
+    margin-top: 0;
+}
+
 .patch-remove-link {
     margin-left: 10px;
     margin-top: 0px;

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -37,7 +37,7 @@ export const assembleCreateNewAssetRequest = (
       areaOfficeName: values?.areaOfficeName ?? "",
       isCouncilProperty: values.isCouncilProperty === "Yes",
       managingOrganisation: values.managingOrganisation,
-      isTMOManaged: values.managingOrganisation != "London Borough of Hackney",
+      isTMOManaged: values.managingOrganisation !== "London Borough of Hackney",
       managingOrganisationId: getManagingOrganisationId(values.managingOrganisation),
     },
     assetCharacteristics: {

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -37,7 +37,7 @@ export const assembleCreateNewAssetRequest = (
       areaOfficeName: values?.areaOfficeName ?? "",
       isCouncilProperty: values.isCouncilProperty === "Yes",
       managingOrganisation: values.managingOrganisation,
-      isTMOManaged: values.isTMOManaged === "Yes",
+      isTMOManaged: values.managingOrganisation != "London Borough of Hackney",
       managingOrganisationId: getManagingOrganisationId(values.managingOrganisation),
     },
     assetCharacteristics: {

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -13,6 +13,12 @@ exports[`renders the whole 'New asset form' view 1`] = `
   >
     New property
   </h1>
+  <span
+    class="govuk-hint lbh-hint"
+    id="new-property-disclaimer"
+  >
+    A new property will immediately be available for users of Manage My Home. Information is validated in most fields, but all protections are not in place, so some selections may result in mismatched information. It is recommended to thoroughly check the submission before adding the new asset.      
+  </span>
   <section>
     <div
       id="new-property-form"
@@ -414,6 +420,42 @@ exports[`renders the whole 'New asset form' view 1`] = `
         <h2
           class="lbh-heading-h2"
         >
+          Asset details
+        </h2>
+        <label
+          class="govuk-label lbh-label"
+          for="window-type"
+        >
+          Window type
+        </label>
+        <input
+          class="govuk-input lbh-input"
+          data-testid="window-type"
+          id="window-type"
+          name="windowType"
+          value=""
+        />
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="year-constructed"
+          >
+            Year constructed
+          </label>
+          <input
+            class="govuk-input lbh-input"
+            data-testid="year-constructed"
+            id="year-constructed"
+            name="yearConstructed"
+            type="text"
+            value=""
+          />
+        </div>
+        <h2
+          class="lbh-heading-h2"
+        >
           Property management
         </h2>
         <label
@@ -558,6 +600,68 @@ exports[`renders the whole 'New asset form' view 1`] = `
             WY - Wyke TMO (HN)
           </option>
         </select>
+        <label
+          class="govuk-label lbh-label"
+          for="patches"
+        >
+          Patches
+        </label>
+        <div
+          id="property-patches-container"
+        >
+          <div>
+            <svg
+              class="mtfh-icon"
+              focusable="false"
+              height="50"
+              stroke="#00703c"
+              viewBox="0 0 42 42"
+              width="50"
+            >
+              <title>
+                Loading...
+              </title>
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <g
+                  stroke-width="5"
+                  transform="translate(3 3)"
+                >
+                  <circle
+                    cx="18"
+                    cy="18"
+                    r="18"
+                    stroke-opacity=".5"
+                  />
+                  <path
+                    d="M36 18c0-9.94-8.06-18-18-18"
+                    transform="rotate(112.708 18 18)"
+                  >
+                    <animatetransform
+                      attributeName="transform"
+                      dur="1s"
+                      from="0 18 18"
+                      repeatCount="indefinite"
+                      to="360 18 18"
+                      type="rotate"
+                    />
+                  </path>
+                </g>
+              </g>
+            </svg>
+          </div>
+        </div>
+        <div>
+          <button
+            class="lbh-link"
+            data-testid="patch-add-link"
+            id="patch-add-link"
+          >
+            Add another patch
+          </button>
+        </div>
         <div
           class="govuk-form-group lbh-form-group"
         >
@@ -673,157 +777,6 @@ exports[`renders the whole 'New asset form' view 1`] = `
               Cranston Estate TMO
             </option>
           </select>
-        </div>
-        <div
-          class="govuk-form-group lbh-form-group"
-        >
-          <fieldset
-            class="govuk-fieldset"
-          >
-            <legend
-              class="govuk-label lbh-label"
-            >
-              Is TMO managed?
-            </legend>
-            <div
-              class="govuk-radios lbh-radios"
-            >
-              <div
-                class="govuk-radios__item"
-              >
-                <input
-                  class="govuk-radios__input"
-                  data-testid="is-tmo-managed-yes"
-                  id="is-tmo-managed-yes"
-                  name="isTMOManaged"
-                  type="radio"
-                  value="Yes"
-                />
-                <label
-                  class="govuk-label govuk-radios__label"
-                  for="is-tmo-managed-yes"
-                >
-                  Yes
-                </label>
-              </div>
-              <div
-                class="govuk-radios__item"
-              >
-                <input
-                  class="govuk-radios__input"
-                  data-testid="is-tmo-managed-no"
-                  id="is-tmo-managed-no"
-                  name="isTMOManaged"
-                  type="radio"
-                  value="No"
-                />
-                <label
-                  class="govuk-label govuk-radios__label"
-                  for="is-tmo-managed-no"
-                >
-                  No
-                </label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-        <label
-          class="govuk-label lbh-label"
-          for="patches"
-        >
-          Patches
-        </label>
-        <div
-          id="property-patches-container"
-        >
-          <div>
-            <svg
-              class="mtfh-icon"
-              focusable="false"
-              height="50"
-              stroke="#00703c"
-              viewBox="0 0 42 42"
-              width="50"
-            >
-              <title>
-                Loading...
-              </title>
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <g
-                  stroke-width="5"
-                  transform="translate(3 3)"
-                >
-                  <circle
-                    cx="18"
-                    cy="18"
-                    r="18"
-                    stroke-opacity=".5"
-                  />
-                  <path
-                    d="M36 18c0-9.94-8.06-18-18-18"
-                    transform="rotate(112.708 18 18)"
-                  >
-                    <animatetransform
-                      attributeName="transform"
-                      dur="1s"
-                      from="0 18 18"
-                      repeatCount="indefinite"
-                      to="360 18 18"
-                      type="rotate"
-                    />
-                  </path>
-                </g>
-              </g>
-            </svg>
-          </div>
-        </div>
-        <div>
-          <button
-            class="lbh-link"
-            data-testid="patch-add-link"
-            id="patch-add-link"
-          >
-            Add another patch
-          </button>
-        </div>
-        <h2
-          class="lbh-heading-h2"
-        >
-          Asset details
-        </h2>
-        <label
-          class="govuk-label lbh-label"
-          for="window-type"
-        >
-          Window type
-        </label>
-        <input
-          class="govuk-input lbh-input"
-          data-testid="window-type"
-          id="window-type"
-          name="windowType"
-          value=""
-        />
-        <div
-          class="govuk-form-group lbh-form-group"
-        >
-          <label
-            class="govuk-label lbh-label"
-            for="year-constructed"
-          >
-            Year constructed
-          </label>
-          <input
-            class="govuk-input lbh-input"
-            data-testid="year-constructed"
-            id="year-constructed"
-            name="yearConstructed"
-            type="text"
-            value=""
-          />
         </div>
         <div
           class="new-property-form-actions"

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -17,7 +17,8 @@ exports[`renders the whole 'New asset form' view 1`] = `
     class="govuk-hint lbh-hint"
     id="new-property-disclaimer"
   >
-    A new property will immediately be available for users of Manage My Home. Information is validated in most fields, but all protections are not in place, so some selections may result in mismatched information. It is recommended to thoroughly check the submission before adding the new asset.      
+    A new property will immediately be available for users of Manage My Home. Information is validated in most fields, but all protections are not in place, so some selections may result in mismatched information. It is recommended to thoroughly check the submission before adding the new asset.
+     
   </span>
   <section>
     <div

--- a/src/views/new-asset-view/layout.tsx
+++ b/src/views/new-asset-view/layout.tsx
@@ -35,7 +35,8 @@ export const NewPropertyLayout = (): JSX.Element => {
         Back
       </Link>
       <h1 className="lbh-heading-h1">New property</h1>
-
+      <span id="new-property-disclaimer" className="govuk-hint lbh-hint">
+      A new property will immediately be available for users of Manage My Home. Information is validated in most fields, but all protections are not in place, so some selections may result in mismatched information. It is recommended to thoroughly check the submission before adding the new asset.      </span>
       {showSuccess && (
         <StatusBox variant="success" title={locale.assets.newPropertyAddedSuccessMessage}>
           {renderNewPropertyLink()}

--- a/src/views/new-asset-view/layout.tsx
+++ b/src/views/new-asset-view/layout.tsx
@@ -36,7 +36,11 @@ export const NewPropertyLayout = (): JSX.Element => {
       </Link>
       <h1 className="lbh-heading-h1">New property</h1>
       <span id="new-property-disclaimer" className="govuk-hint lbh-hint">
-      A new property will immediately be available for users of Manage My Home. Information is validated in most fields, but all protections are not in place, so some selections may result in mismatched information. It is recommended to thoroughly check the submission before adding the new asset.      </span>
+        A new property will immediately be available for users of Manage My Home.
+        Information is validated in most fields, but all protections are not in place, so
+        some selections may result in mismatched information. It is recommended to
+        thoroughly check the submission before adding the new asset.{" "}
+      </span>
       {showSuccess && (
         <StatusBox variant="success" title={locale.assets.newPropertyAddedSuccessMessage}>
           {renderNewPropertyLink()}


### PR DESCRIPTION
Following the [feedback ](https://docs.google.com/document/d/1hm26uKZF-tlBBJhl7BLfSy1CLeWxMwfD82JlYgTpMy4/edit)after the first round of testing this feature, I've applied the following changes.

- Moved "Asset details" section under "Address" section - [Screenshot](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/b18d7105-bb12-419e-a83d-b4d858b4c54c)
- Moved "Patches" field after "Area office name" field - [Screenshot](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/695e7f08-16dd-43c8-88cd-fb2a38f409a8)
- Added disclaimer under "New Property" heading to make users aware they have the power to input incorrect data - [Screenshot](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/a9c2c83b-420c-4a64-b7b5-7fb57e32b655)
- Removed `isTmoManaged` field from form and schema (and any other references).
- `isTmoManaged` in `CreateNewAssetRequest` now depends on the form value of `managingOrganisation`. If the selected `managingOrganisation` is "London Borough of Hackney", then `isTmoManaged` will be `false`, otherwise it will be `true`.


Additional changes:
- Added error message to inform user form cannot be submitted due to errors (this is helpful as the user may miss one of the errors on one of the required fields at the very top of the form, which may not be visible when the user clicks the "Create new property" submit button. - [Screenshot](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/4cf4f35f-eb94-4deb-8e0d-b2e57f20a804)
-  Removed unused "Sub block" field and references.

