### PR TITLE
MR-708 - Fix bugs: (1) Empty box shown instead of asset hierarchy (2) ChildrenAssets sometimes do not render

### DIFF
--- a/src/components/property-tree/property-tree-utils.tsx
+++ b/src/components/property-tree/property-tree-utils.tsx
@@ -70,17 +70,19 @@ const addParentsAndPrinciple = (
   );
 
   if (validParents.length) {
-    for (const [i, v] of validParents.entries()) {
+    for (const [validParentIndex, validParentValue] of validParents.entries()) {
       // Attach principle to last parent
-      if (i === validParents.length - 1) {
+      if (validParentIndex === validParents.length - 1) {
         principle.title = (
-          <a className="lbh-link govuk-link" href={`/property/${v.id}`}>
-            {v.name}
+          <a className="lbh-link govuk-link" href={`/property/${validParentValue.id}`}>
+            {validParentValue.name}
           </a>
         );
         treeViewElements.push(principle);
       } else {
-        treeViewElements.push(generateNode(v.name, [], v.id));
+        treeViewElements.push(
+          generateNode(validParentValue.name, [], validParentValue.id),
+        );
       }
     }
   } else {

--- a/src/components/property-tree/property-tree-utils.tsx
+++ b/src/components/property-tree/property-tree-utils.tsx
@@ -46,7 +46,7 @@ const generateNode = (name: string, childList: TreeAsset[], id: string): TreeAss
 const generatePrinciple = (asset: Asset, childNodes: TreeAsset[]): TreeAsset => {
   return {
     title: (
-      <span>{asset.assetLocation?.parentAssets?.length ? "Principle" : "Hackney"}</span>
+      <span>Hackney</span>
     ),
     children: [
       {
@@ -67,10 +67,13 @@ const addParentsAndPrinciple = (
 ) => {
   const treeViewElements: TreeAsset[] = [];
 
-  if (asset.assetLocation?.parentAssets?.length) {
-    const validParents = asset.assetLocation.parentAssets.filter(
-      (el) => !excludedTreeAssets.includes(el.id),
-    );
+  const validParents = asset.assetLocation.parentAssets.filter(
+    (el) => !excludedTreeAssets.includes(el.id),
+  );
+
+  console.log("validParents", validParents)
+
+  if (validParents.length) {
 
     for (const [i, v] of validParents.entries()) {
       // Attach principle to last parent
@@ -89,6 +92,7 @@ const addParentsAndPrinciple = (
     treeViewElements.push(generatePrinciple(asset, childNodes));
   }
 
+  console.log("treeViewElements", treeViewElements)
   return treeViewElements;
 };
 

--- a/src/components/property-tree/property-tree-utils.tsx
+++ b/src/components/property-tree/property-tree-utils.tsx
@@ -45,9 +45,7 @@ const generateNode = (name: string, childList: TreeAsset[], id: string): TreeAss
 
 const generatePrinciple = (asset: Asset, childNodes: TreeAsset[]): TreeAsset => {
   return {
-    title: (
-      <span>Hackney</span>
-    ),
+    title: <span>Hackney</span>,
     children: [
       {
         title: `${asset.assetAddress.addressLine1} (this asset)`,
@@ -71,10 +69,7 @@ const addParentsAndPrinciple = (
     (el) => !excludedTreeAssets.includes(el.id),
   );
 
-  console.log("validParents", validParents)
-
   if (validParents.length) {
-
     for (const [i, v] of validParents.entries()) {
       // Attach principle to last parent
       if (i === validParents.length - 1) {
@@ -92,7 +87,6 @@ const addParentsAndPrinciple = (
     treeViewElements.push(generatePrinciple(asset, childNodes));
   }
 
-  console.log("treeViewElements", treeViewElements)
   return treeViewElements;
 };
 

--- a/src/components/property-tree/property-tree.tsx
+++ b/src/components/property-tree/property-tree.tsx
@@ -28,11 +28,11 @@ export const PropertyTree = ({ asset, childAssets }: PropertyTreeProps): JSX.Ele
   useEffect(() => {
     setChildNodes(addChildrenAssets(childAssets));
   }, [childAssets]);
-  
+
   useEffect(() => {
     const principle = generatePrinciple(asset, childNodes);
     setTreeViewData(
-      addParentsAndPrinciple(asset, childNodes, excludedTreeAssets, principle)
+      addParentsAndPrinciple(asset, childNodes, excludedTreeAssets, principle),
     );
   }, [childNodes, asset]);
 

--- a/src/components/property-tree/property-tree.tsx
+++ b/src/components/property-tree/property-tree.tsx
@@ -23,16 +23,18 @@ export const PropertyTree = ({ asset, childAssets }: PropertyTreeProps): JSX.Ele
   const excludedTreeAssets = "656feda1-896f-b136-da84-163ee4f1be6c"; // Hackney Homes
 
   const [treeViewData, setTreeViewData] = useState<TreeAsset[]>([]);
-  const childNodes = addChildrenAssets(childAssets);
-  const principle = generatePrinciple(asset, childNodes);
+  const [childNodes, setChildNodes] = useState<TreeAsset[]>([]);
 
   useEffect(() => {
+    setChildNodes(addChildrenAssets(childAssets));
+  }, [childAssets]);
+  
+  useEffect(() => {
+    const principle = generatePrinciple(asset, childNodes);
     setTreeViewData(
-      addParentsAndPrinciple(asset, childNodes, excludedTreeAssets, principle),
+      addParentsAndPrinciple(asset, childNodes, excludedTreeAssets, principle)
     );
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [childNodes, asset]);
 
   const onChangeHandler = (treeData: TreeAsset[]) => {
     setTreeViewData(treeData);


### PR DESCRIPTION
### Issue 1

For some assets, when `treeViewData` (in `addParentsAndPrinciple()`) ended up being equal to an empty array, an empty box would show, instead of showing the asset by itself:

![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/58656cae-bdbe-4d0d-8bc2-c19bcdff7256)


A slight change in the logic fixed the issue:
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/c1a3bfbb-803d-49f0-8902-6663624d6347)

### Issue 2

Once we managed to retrieve children assets, I noticed these would not always be displayed. If you reloaded the page 20 times, sometimes they would appear and some other times they would not.

This was due to the fact that `childNodes` was not part of `PropertyTree`'s state, but it was just variable, defined once. Refactored `PropertyTree` component by adding a second `useEffect` hook and modifying the original one.
