### PR TITLE
MR-733 - Allow address edit of assets with no UPRN 

### DIFF
--- a/src/components/asset-sidebar/index.tsx
+++ b/src/components/asset-sidebar/index.tsx
@@ -62,11 +62,10 @@ export const AssetSideBar = ({
           {isAuthorisedForGroups(assetAdminAuthGroups) && (
             <Button
               as={RouterLink}
-              to={assetAddress.uprn ? `/property/edit/${id}` : "#"}
-              isDisabled={!assetAddress.uprn}
+              to={`/property/edit/${id}`}
               data-testid="edit-address-button"
             >
-              {assetAddress.uprn ? "Edit address details" : "Cannot edit: UPRN missing"}
+              Edit address details
             </Button>
           )}
           {showCautionaryAlerts && <CautionaryAlertsDetails alerts={alerts} />}

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -25,7 +25,7 @@ import { Center, Spinner } from "@mtfh/common/lib/components";
 
 import "../styles.scss";
 
-export interface EditableAddressProperties {
+export interface EditableAddressProps {
   llpgAddress: Address | null;
   currentAddress: AssetAddress;
   assetHasUprn: boolean;
@@ -51,7 +51,7 @@ export const EditableAddress = ({
   setErrorDescription,
   setCurrentAssetAddress,
   tenureApiObject,
-}: EditableAddressProperties): JSX.Element => {
+}: EditableAddressProps): JSX.Element => {
   const [addressEditSuccessful, setAddressEditSuccessful] = useState<boolean>(false);
 
   const handleSubmit = async (formValues: PatchAssetAddressFormValues) => {

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -13,7 +13,7 @@ import {
   buildUpdateAddressDetailsRequest,
   getAssetVersionNumber,
   getLlpgAddressFormValues,
-  getNonUprnAddressFormValues,
+  getCurrentAddressFormValues,
 } from "./utils";
 
 import { Address } from "@mtfh/common/lib/api/address/v1/types";
@@ -106,7 +106,7 @@ export const EditableAddress = ({
     if (llpgAddress && assetHasUprn) {
       return getLlpgAddressFormValues(llpgAddress);
     }
-    return getNonUprnAddressFormValues(currentAddress);
+    return getCurrentAddressFormValues(currentAddress);
   };
 
   if (assetHasUprn && loading && !llpgAddress) {

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -12,6 +12,8 @@ import {
   buildEditTenureRequest,
   buildUpdateAddressDetailsRequest,
   getAssetVersionNumber,
+  getLlpgAddressFormValues,
+  getNonUprnAddressFormValues,
 } from "./utils";
 
 import { Address } from "@mtfh/common/lib/api/address/v1/types";
@@ -25,6 +27,8 @@ import "../styles.scss";
 
 export interface EditableAddressProperties {
   llpgAddress: Address | null;
+  currentAddress: AssetAddress;
+  assetHasUprn: boolean;
   loading: boolean;
   assetDetails: Asset;
   setShowSuccess: (value: boolean) => void;
@@ -37,6 +41,8 @@ export interface EditableAddressProperties {
 
 export const EditableAddress = ({
   llpgAddress,
+  currentAddress,
+  assetHasUprn,
   loading,
   assetDetails,
   setShowSuccess,
@@ -134,6 +140,14 @@ export const EditableAddress = ({
       });
   };
 
+  const getFormInitialValues = () => {
+    if (llpgAddress && assetHasUprn) {
+      return getLlpgAddressFormValues(llpgAddress)
+    } else {
+      return getNonUprnAddressFormValues(currentAddress)
+    }
+  }
+
   if (!llpgAddress && loading) {
     return (
       <Center>
@@ -145,14 +159,7 @@ export const EditableAddress = ({
   return (
     <>
       <Formik<EditableAddressFormData>
-        initialValues={{
-          postPreamble: "",
-          addressLine1: llpgAddress?.line1 ? llpgAddress.line1 : "",
-          addressLine2: llpgAddress?.line2 ? llpgAddress.line2 : "",
-          addressLine3: llpgAddress?.line3 ? llpgAddress.line3 : "",
-          addressLine4: llpgAddress?.town ? llpgAddress.town : "",
-          postcode: llpgAddress?.postcode ? llpgAddress.postcode : "",
-        }}
+        initialValues={getFormInitialValues()}
         validationSchema={editableAddressSchema}
         onSubmit={(values) => handleSubmit(values)}
       >

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -12,8 +12,8 @@ import {
   buildEditTenureRequest,
   buildUpdateAddressDetailsRequest,
   getAssetVersionNumber,
-  getLlpgAddressFormValues,
   getCurrentAddressFormValues,
+  getLlpgAddressFormValues,
 } from "./utils";
 
 import { Address } from "@mtfh/common/lib/api/address/v1/types";

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
-import { Link as RouterLink } from "react-router-dom";
 
 import { Field, Form, Formik } from "formik";
 
 import { locale } from "../../../services";
+import { FormActionButtons } from "./form-action-buttons";
 import { EditableAddressFormData, editableAddressSchema } from "./schema";
 import { PatchAssetAddressFormValues } from "./types";
 import {
@@ -53,44 +53,6 @@ export const EditableAddress = ({
   tenureApiObject,
 }: EditableAddressProperties): JSX.Element => {
   const [addressEditSuccessful, setAddressEditSuccessful] = useState<boolean>(false);
-
-  const renderFormActionButtons = () => {
-    if (!addressEditSuccessful) {
-      return (
-        <>
-          <div className="edit-asset-form-actions">
-            <button
-              className="govuk-button lbh-button"
-              data-module="govuk-button"
-              type="submit"
-              id="submit-address-button"
-            >
-              Update to this address
-            </button>
-
-            <RouterLink
-              to={`/property/${assetDetails.id}`}
-              className="govuk-button govuk-secondary lbh-button lbh-button--secondary"
-            >
-              Cancel
-            </RouterLink>
-          </div>
-        </>
-      );
-    }
-    return (
-      <>
-        <div className="form-actions">
-          <RouterLink
-            to={`/property/${assetDetails.id}`}
-            className="govuk-button lbh-button"
-          >
-            Back to asset view
-          </RouterLink>
-        </div>
-      </>
-    );
-  };
 
   const handleSubmit = async (formValues: PatchAssetAddressFormValues) => {
     setShowSuccess(false);
@@ -142,11 +104,10 @@ export const EditableAddress = ({
 
   const getFormInitialValues = () => {
     if (llpgAddress && assetHasUprn) {
-      return getLlpgAddressFormValues(llpgAddress)
-    } else {
-      return getNonUprnAddressFormValues(currentAddress)
+      return getLlpgAddressFormValues(llpgAddress);
     }
-  }
+    return getNonUprnAddressFormValues(currentAddress);
+  };
 
   if (assetHasUprn && loading && !llpgAddress) {
     return (
@@ -322,8 +283,10 @@ export const EditableAddress = ({
                   disabled={!!addressEditSuccessful}
                 />
               </div>
-
-              {renderFormActionButtons()}
+              <FormActionButtons
+                assetGuid={assetDetails.id}
+                addressEditSuccessful={addressEditSuccessful}
+              />
             </Form>
           </div>
         )}

--- a/src/components/edit-asset-address-form/editable-address/editable-address.tsx
+++ b/src/components/edit-asset-address-form/editable-address/editable-address.tsx
@@ -148,7 +148,7 @@ export const EditableAddress = ({
     }
   }
 
-  if (!llpgAddress && loading) {
+  if (assetHasUprn && loading && !llpgAddress) {
     return (
       <Center>
         <Spinner />
@@ -167,7 +167,7 @@ export const EditableAddress = ({
           <div id="edit-address-form">
             <Form>
               <h3 className="lbh-heading-h3">
-                {llpgAddress
+                {llpgAddress && assetHasUprn
                   ? "Suggestion from the Local Gazetteer"
                   : "New address details"}
               </h3>

--- a/src/components/edit-asset-address-form/editable-address/form-action-buttons.tsx
+++ b/src/components/edit-asset-address-form/editable-address/form-action-buttons.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Link as RouterLink } from "react-router-dom";
+
+export interface FormActionButtonsProps {
+  assetGuid: string;
+  addressEditSuccessful: boolean;
+}
+
+export const FormActionButtons = ({
+  assetGuid,
+  addressEditSuccessful,
+}: FormActionButtonsProps): JSX.Element => {
+  if (!addressEditSuccessful) {
+    return (
+      <>
+        <div className="edit-asset-form-actions">
+          <button
+            className="govuk-button lbh-button"
+            data-module="govuk-button"
+            type="submit"
+            id="submit-address-button"
+          >
+            Update to this address
+          </button>
+
+          <RouterLink
+            to={`/property/${assetGuid}`}
+            className="govuk-button govuk-secondary lbh-button lbh-button--secondary"
+          >
+            Cancel
+          </RouterLink>
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      <div className="form-actions">
+        <RouterLink to={`/property/${assetGuid}`} className="govuk-button lbh-button">
+          Back to asset view
+        </RouterLink>
+      </div>
+    </>
+  );
+};

--- a/src/components/edit-asset-address-form/editable-address/utils.ts
+++ b/src/components/edit-asset-address-form/editable-address/utils.ts
@@ -1,3 +1,4 @@
+import { Address } from "@mtfh/common/lib/api/address/v1";
 import { PatchAssetAddressFormValues } from "./types";
 
 import {
@@ -73,3 +74,25 @@ export const buildAssetAddress = (
   postPreamble: editAssetAddressRequest.assetAddress.postPreamble,
   uprn: assetDetails.assetAddress.uprn,
 });
+
+export const getLlpgAddressFormValues = (editableAddress: Address) => {
+  return {
+    postPreamble: "",
+    addressLine1: editableAddress?.line1 ? editableAddress.line1 : "",
+    addressLine2: editableAddress?.line2 ? editableAddress.line2 : "",
+    addressLine3: editableAddress?.line3 ? editableAddress.line3 : "",
+    addressLine4: editableAddress?.town ? editableAddress.town : "",
+    postcode: editableAddress?.postcode ? editableAddress.postcode : "",
+  }
+}
+
+export const getNonUprnAddressFormValues = (editableAddress: AssetAddress) => {
+  return {
+    postPreamble: "",
+    addressLine1: editableAddress?.addressLine1 ? editableAddress.addressLine1 : "",
+    addressLine2: editableAddress?.addressLine2 ? editableAddress.addressLine2 : "",
+    addressLine3: editableAddress?.addressLine3 ? editableAddress.addressLine3 : "",
+    addressLine4: editableAddress?.addressLine4 ? editableAddress.addressLine4 : "",
+    postcode: editableAddress?.postCode ? editableAddress.postCode : "",
+  }
+}

--- a/src/components/edit-asset-address-form/editable-address/utils.ts
+++ b/src/components/edit-asset-address-form/editable-address/utils.ts
@@ -75,24 +75,24 @@ export const buildAssetAddress = (
   uprn: assetDetails.assetAddress.uprn,
 });
 
-export const getLlpgAddressFormValues = (editableAddress: Address) => {
+export const getLlpgAddressFormValues = (llpgAddress: Address) => {
   return {
     postPreamble: "",
-    addressLine1: editableAddress?.line1 ? editableAddress.line1 : "",
-    addressLine2: editableAddress?.line2 ? editableAddress.line2 : "",
-    addressLine3: editableAddress?.line3 ? editableAddress.line3 : "",
-    addressLine4: editableAddress?.town ? editableAddress.town : "",
-    postcode: editableAddress?.postcode ? editableAddress.postcode : "",
+    addressLine1: llpgAddress?.line1 || "",
+    addressLine2: llpgAddress?.line2 || "",
+    addressLine3: llpgAddress?.line3 || "",
+    addressLine4: llpgAddress?.town || "",
+    postcode: llpgAddress?.postcode || "",
   };
 };
 
-export const getCurrentAddressFormValues = (editableAddress: AssetAddress) => {
+export const getCurrentAddressFormValues = (currentAddress: AssetAddress) => {
   return {
-    postPreamble: editableAddress?.postPreamble ? editableAddress?.postPreamble : "",
-    addressLine1: editableAddress?.addressLine1 ? editableAddress.addressLine1 : "",
-    addressLine2: editableAddress?.addressLine2 ? editableAddress.addressLine2 : "",
-    addressLine3: editableAddress?.addressLine3 ? editableAddress.addressLine3 : "",
-    addressLine4: editableAddress?.addressLine4 ? editableAddress.addressLine4 : "",
-    postcode: editableAddress?.postCode ? editableAddress.postCode : "",
+    postPreamble: currentAddress?.postPreamble || "",
+    addressLine1: currentAddress?.addressLine1 || "",
+    addressLine2: currentAddress?.addressLine2 || "",
+    addressLine3: currentAddress?.addressLine3 || "",
+    addressLine4: currentAddress?.addressLine4 || "",
+    postcode: currentAddress?.postCode || "",
   };
 };

--- a/src/components/edit-asset-address-form/editable-address/utils.ts
+++ b/src/components/edit-asset-address-form/editable-address/utils.ts
@@ -1,6 +1,6 @@
-import { Address } from "@mtfh/common/lib/api/address/v1";
 import { PatchAssetAddressFormValues } from "./types";
 
+import { Address } from "@mtfh/common/lib/api/address/v1";
 import {
   Asset,
   AssetAddress,
@@ -83,8 +83,8 @@ export const getLlpgAddressFormValues = (editableAddress: Address) => {
     addressLine3: editableAddress?.line3 ? editableAddress.line3 : "",
     addressLine4: editableAddress?.town ? editableAddress.town : "",
     postcode: editableAddress?.postcode ? editableAddress.postcode : "",
-  }
-}
+  };
+};
 
 export const getNonUprnAddressFormValues = (editableAddress: AssetAddress) => {
   return {
@@ -94,5 +94,5 @@ export const getNonUprnAddressFormValues = (editableAddress: AssetAddress) => {
     addressLine3: editableAddress?.addressLine3 ? editableAddress.addressLine3 : "",
     addressLine4: editableAddress?.addressLine4 ? editableAddress.addressLine4 : "",
     postcode: editableAddress?.postCode ? editableAddress.postCode : "",
-  }
-}
+  };
+};

--- a/src/components/edit-asset-address-form/editable-address/utils.ts
+++ b/src/components/edit-asset-address-form/editable-address/utils.ts
@@ -88,7 +88,7 @@ export const getLlpgAddressFormValues = (editableAddress: Address) => {
 
 export const getNonUprnAddressFormValues = (editableAddress: AssetAddress) => {
   return {
-    postPreamble: "",
+    postPreamble: editableAddress?.postPreamble ? editableAddress?.postPreamble : "",
     addressLine1: editableAddress?.addressLine1 ? editableAddress.addressLine1 : "",
     addressLine2: editableAddress?.addressLine2 ? editableAddress.addressLine2 : "",
     addressLine3: editableAddress?.addressLine3 ? editableAddress.addressLine3 : "",

--- a/src/components/edit-asset-address-form/editable-address/utils.ts
+++ b/src/components/edit-asset-address-form/editable-address/utils.ts
@@ -86,7 +86,7 @@ export const getLlpgAddressFormValues = (editableAddress: Address) => {
   };
 };
 
-export const getNonUprnAddressFormValues = (editableAddress: AssetAddress) => {
+export const getCurrentAddressFormValues = (editableAddress: AssetAddress) => {
   return {
     postPreamble: editableAddress?.postPreamble ? editableAddress?.postPreamble : "",
     addressLine1: editableAddress?.addressLine1 ? editableAddress.addressLine1 : "",

--- a/src/components/edit-asset-address-form/reference-address/reference-address.tsx
+++ b/src/components/edit-asset-address-form/reference-address/reference-address.tsx
@@ -4,13 +4,13 @@ import { AssetAddress } from "@mtfh/common/lib/api/asset/v1";
 
 import "../styles.scss";
 
-export interface ReferenceAddressProperties {
+export interface CurrentAddressProps {
   assetAddressDetails: AssetAddress;
 }
 
-export const ReferenceAddress = ({
+export const CurrentAddress = ({
   assetAddressDetails,
-}: ReferenceAddressProperties): JSX.Element => {
+}: CurrentAddressProps): JSX.Element => {
   return (
     <>
       <h3 className="lbh-heading-h3">Current address</h3>

--- a/src/views/asset-edit-view/__snapshots__/asset-edit-view.test.tsx.snap
+++ b/src/views/asset-edit-view/__snapshots__/asset-edit-view.test.tsx.snap
@@ -13,6 +13,11 @@ exports[`renders the whole 'Edit property address' view 1`] = `
   >
     Edit property address
   </h1>
+  <span
+    class="govuk-caption-m lbh-caption"
+  >
+    Addresses are suggested from the Local Gazetteer to bring some standardisation.
+  </span>
   <div
     class="mtfh-address-details"
   >

--- a/src/views/asset-edit-view/__snapshots__/asset-edit-view.test.tsx.snap
+++ b/src/views/asset-edit-view/__snapshots__/asset-edit-view.test.tsx.snap
@@ -13,11 +13,6 @@ exports[`renders the whole 'Edit property address' view 1`] = `
   >
     Edit property address
   </h1>
-  <span
-    class="govuk-caption-m lbh-caption"
-  >
-    New Addresses are suggested from the Local Gazetteer to bring some standardisation.
-  </span>
   <div
     class="mtfh-address-details"
   >

--- a/src/views/asset-edit-view/asset-edit-view.test.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.test.tsx
@@ -379,3 +379,37 @@ test("unauthorized message is shown for unauthorized users", async () => {
     expect(unauthorizedErrorMessage).toBeVisible();
   });
 });
+
+test("when editing an address without a UPRN, the editable fields are filled with current address details", async () => {
+  const assetWithoutUprn = assetData;
+
+  // Remove UPRN property from our test asset (which has one)
+  assetWithoutUprn.assetAddress.uprn = ""
+  
+  render(<AssetEditView />, {
+    url: `/property/edit/${assetWithoutUprn.id}`,
+    path: "/property/edit/:assetId",
+  });
+
+  // This allows the test to wait for the page to be populated, after receiving data from the mock Address and Asset APIs
+  // Unlike previous tests, now we expect to find only 2 headings, as the "Current address" section is not visible
+  await waitFor(() => expect(screen.getAllByRole("heading")).toHaveLength(2));
+
+  const currentAddressLine1 = screen.getByTestId("address-line-1");
+  expect(currentAddressLine1).toHaveValue("51 GREENWOOD ROAD - FLAT B");
+
+  const currentAddressLine2 = screen.getByTestId("address-line-2");
+  expect(currentAddressLine2).toHaveValue("");
+
+  const currentAddressLine3 = screen.getByTestId("address-line-3");
+  expect(currentAddressLine3).toHaveValue("");
+
+  const currentAddressLine4 = screen.getByTestId("address-line-4");
+  expect(currentAddressLine4).toHaveValue("");
+
+  const currentAddressPostcode = screen.getByTestId("postcode");
+  expect(currentAddressPostcode).toHaveValue("E8 1QT");
+
+  const llpgPostPreamble = screen.getByTestId("post-preamble");
+  expect(llpgPostPreamble).toHaveValue("X");
+});

--- a/src/views/asset-edit-view/asset-edit-view.test.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.test.tsx
@@ -384,8 +384,8 @@ test("when editing an address without a UPRN, the editable fields are filled wit
   const assetWithoutUprn = assetData;
 
   // Remove UPRN property from our test asset (which has one)
-  assetWithoutUprn.assetAddress.uprn = ""
-  
+  assetWithoutUprn.assetAddress.uprn = "";
+
   render(<AssetEditView />, {
     url: `/property/edit/${assetWithoutUprn.id}`,
     path: "/property/edit/:assetId",

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 
-import { ReferenceAddress } from "../../components/edit-asset-address-form/reference-address";
 import { EditableAddress } from "../../components/edit-asset-address-form/editable-address";
+import { ReferenceAddress } from "../../components/edit-asset-address-form/reference-address";
 import { locale } from "../../services";
 
 import { Address, getAddressViaUprn } from "@mtfh/common/lib/api/address/v1";
@@ -25,7 +25,7 @@ export const AssetEditLayout = ({
     assetDetails.assetAddress,
   );
   const [llpgAddress, setLlpgAddress] = useState<Address | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [showSuccess, setShowSuccess] = useState<boolean>(false);
   const [showError, setShowError] = useState<boolean>(false);
   const [errorHeading, setErrorHeading] = useState<string | null>(null);
@@ -50,7 +50,7 @@ export const AssetEditLayout = ({
         .finally(() => setLoading(false));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [assetDetails]);
 
   const renderLlpgSubHeading = () => {
     if (assetDetails.assetAddress.uprn) {
@@ -97,7 +97,7 @@ export const AssetEditLayout = ({
       <div className="mtfh-address-details">
         <section>
           <EditableAddress
-            llpgAddress={llpgAddress}
+            llpgAddress={llpgAddress ? llpgAddress : null}
             currentAddress={currentAssetAddress}
             assetHasUprn={!!assetDetails.assetAddress.uprn}
             loading={loading}

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -33,7 +33,7 @@ export const AssetEditLayout = ({
 
   useEffect(() => {
     if (assetDetails.assetAddress.uprn) {
-      setLoading(true)
+      setLoading(true);
       getAddressViaUprn(assetDetails.assetAddress.uprn)
         .then((searchAddressResponse) => {
           if (searchAddressResponse.addresses) {
@@ -41,7 +41,9 @@ export const AssetEditLayout = ({
           }
         })
         .catch(() => {
-          setErrorHeading("Unable to retrieve address suggestion from the Local Gazetteer");
+          setErrorHeading(
+            "Unable to retrieve address suggestion from the Local Gazetteer",
+          );
           setErrorDescription(
             "Please refresh the page and try again, otherwise you are still able to edit the blank fields manually.",
           );
@@ -55,11 +57,10 @@ export const AssetEditLayout = ({
   const renderLlpgSubHeading = () => {
     if (assetDetails.assetAddress.uprn) {
       <span className="govuk-caption-m lbh-caption">
-        Addresses are suggested from the Local Gazetteer to bring some
-        standardisation.
-      </span>
+        Addresses are suggested from the Local Gazetteer to bring some standardisation.
+      </span>;
     }
-  }
+  };
 
   const renderReferenceAddress = () => {
     if (assetDetails.assetAddress.uprn) {
@@ -67,9 +68,9 @@ export const AssetEditLayout = ({
         <section>
           <ReferenceAddress assetAddressDetails={currentAssetAddress} />
         </section>
-      )
+      );
     }
-  }
+  };
 
   return (
     <>
@@ -97,7 +98,7 @@ export const AssetEditLayout = ({
       <div className="mtfh-address-details">
         <section>
           <EditableAddress
-            llpgAddress={llpgAddress ? llpgAddress : null}
+            llpgAddress={llpgAddress || null}
             currentAddress={currentAssetAddress}
             assetHasUprn={!!assetDetails.assetAddress.uprn}
             loading={loading}

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -33,6 +33,7 @@ export const AssetEditLayout = ({
 
   useEffect(() => {
     if (assetDetails.assetAddress.uprn) {
+      console.log("assetDetails.assetAddress.uprn", assetDetails.assetAddress.uprn)
       setLoading(true);
       getAddressViaUprn(assetDetails.assetAddress.uprn)
         .then((searchAddressResponse) => {
@@ -98,7 +99,7 @@ export const AssetEditLayout = ({
             tenureApiObject={tenureApiObject}
           />
         </section>
-        {assetDetails.assetAddress.uprn && (
+        {assetDetails.assetAddress.uprn && llpgAddress && (
           <section>
             <CurrentAddress assetAddressDetails={currentAssetAddress} />
           </section>

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 
-import { EditableAddress } from "../../components/edit-asset-address-form/editable-address";
 import { ReferenceAddress } from "../../components/edit-asset-address-form/reference-address";
+import { EditableAddress } from "../../components/edit-asset-address-form/editable-address";
 import { locale } from "../../services";
 
 import { Address, getAddressViaUprn } from "@mtfh/common/lib/api/address/v1";
@@ -12,7 +12,7 @@ import { ErrorSummary, Link, StatusBox } from "@mtfh/common/lib/components";
 
 import "./styles.scss";
 
-export interface AssetEditLayoutProperties {
+export interface AssetEditLayoutProps {
   assetDetails: Asset;
   tenureApiObject: Tenure | undefined;
 }
@@ -20,34 +20,56 @@ export interface AssetEditLayoutProperties {
 export const AssetEditLayout = ({
   assetDetails,
   tenureApiObject,
-}: AssetEditLayoutProperties): JSX.Element => {
+}: AssetEditLayoutProps): JSX.Element => {
   const [currentAssetAddress, setCurrentAssetAddress] = useState<AssetAddress>(
     assetDetails.assetAddress,
   );
   const [llpgAddress, setLlpgAddress] = useState<Address | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(false);
   const [showSuccess, setShowSuccess] = useState<boolean>(false);
   const [showError, setShowError] = useState<boolean>(false);
   const [errorHeading, setErrorHeading] = useState<string | null>(null);
   const [errorDescription, setErrorDescription] = useState<string | null>(null);
 
   useEffect(() => {
-    getAddressViaUprn(assetDetails.assetAddress.uprn)
-      .then((searchAddressResponse) => {
-        if (searchAddressResponse.addresses) {
-          setLlpgAddress(searchAddressResponse.addresses[0]);
-        }
-      })
-      .catch(() => {
-        setErrorHeading("Unable to retrieve address suggestion from the Local Gazetteer");
-        setErrorDescription(
-          "Please refresh the page and try again, otherwise you are still able to edit the blank fields manually.",
-        );
-        setShowError(true);
-      })
-      .finally(() => setLoading(false));
+    if (assetDetails.assetAddress.uprn) {
+      setLoading(true)
+      getAddressViaUprn(assetDetails.assetAddress.uprn)
+        .then((searchAddressResponse) => {
+          if (searchAddressResponse.addresses) {
+            setLlpgAddress(searchAddressResponse.addresses[0]);
+          }
+        })
+        .catch(() => {
+          setErrorHeading("Unable to retrieve address suggestion from the Local Gazetteer");
+          setErrorDescription(
+            "Please refresh the page and try again, otherwise you are still able to edit the blank fields manually.",
+          );
+          setShowError(true);
+        })
+        .finally(() => setLoading(false));
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const renderLlpgSubHeading = () => {
+    if (assetDetails.assetAddress.uprn) {
+      <span className="govuk-caption-m lbh-caption">
+        Addresses are suggested from the Local Gazetteer to bring some
+        standardisation.
+      </span>
+    }
+  }
+
+  const renderReferenceAddress = () => {
+    if (assetDetails.assetAddress.uprn) {
+      return (
+        <section>
+          <ReferenceAddress assetAddressDetails={currentAssetAddress} />
+        </section>
+      )
+    }
+  }
 
   return (
     <>
@@ -55,10 +77,7 @@ export const AssetEditLayout = ({
         Back to asset
       </Link>
       <h1 className="lbh-heading-h1">Edit property address</h1>
-      <span className="govuk-caption-m lbh-caption">
-        New Addresses are suggested from the Local Gazetteer to bring some
-        standardisation.
-      </span>
+      {renderLlpgSubHeading()}
 
       {showSuccess && (
         <StatusBox
@@ -79,6 +98,8 @@ export const AssetEditLayout = ({
         <section>
           <EditableAddress
             llpgAddress={llpgAddress}
+            currentAddress={currentAssetAddress}
+            assetHasUprn={!!assetDetails.assetAddress.uprn}
             loading={loading}
             assetDetails={assetDetails}
             setCurrentAssetAddress={setCurrentAssetAddress}
@@ -89,9 +110,7 @@ export const AssetEditLayout = ({
             tenureApiObject={tenureApiObject}
           />
         </section>
-        <section>
-          <ReferenceAddress assetAddressDetails={currentAssetAddress} />
-        </section>
+        {renderReferenceAddress()}
       </div>
     </>
   );

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 
 import { EditableAddress } from "../../components/edit-asset-address-form/editable-address";
-import { ReferenceAddress } from "../../components/edit-asset-address-form/reference-address";
+import { CurrentAddress } from "../../components/edit-asset-address-form/reference-address";
 import { locale } from "../../services";
 
 import { Address, getAddressViaUprn } from "@mtfh/common/lib/api/address/v1";
@@ -54,31 +54,18 @@ export const AssetEditLayout = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assetDetails]);
 
-  const renderLlpgSubHeading = () => {
-    if (assetDetails.assetAddress.uprn) {
-      <span className="govuk-caption-m lbh-caption">
-        Addresses are suggested from the Local Gazetteer to bring some standardisation.
-      </span>;
-    }
-  };
-
-  const renderReferenceAddress = () => {
-    if (assetDetails.assetAddress.uprn) {
-      return (
-        <section>
-          <ReferenceAddress assetAddressDetails={currentAssetAddress} />
-        </section>
-      );
-    }
-  };
-
   return (
     <>
       <Link as={RouterLink} to={`/property/${assetDetails.id}`} variant="back-link">
         Back to asset
       </Link>
       <h1 className="lbh-heading-h1">Edit property address</h1>
-      {renderLlpgSubHeading()}
+
+      {assetDetails.assetAddress.uprn && (
+        <span className="govuk-caption-m lbh-caption">
+          Addresses are suggested from the Local Gazetteer to bring some standardisation.
+        </span>
+      )}
 
       {showSuccess && (
         <StatusBox
@@ -111,7 +98,11 @@ export const AssetEditLayout = ({
             tenureApiObject={tenureApiObject}
           />
         </section>
-        {renderReferenceAddress()}
+        {assetDetails.assetAddress.uprn && (
+          <section>
+            <CurrentAddress assetAddressDetails={currentAssetAddress} />
+          </section>
+        )}
       </div>
     </>
   );

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -33,7 +33,6 @@ export const AssetEditLayout = ({
 
   useEffect(() => {
     if (assetDetails.assetAddress.uprn) {
-      console.log("assetDetails.assetAddress.uprn", assetDetails.assetAddress.uprn);
       setLoading(true);
       getAddressViaUprn(assetDetails.assetAddress.uprn)
         .then((searchAddressResponse) => {

--- a/src/views/asset-edit-view/layout.tsx
+++ b/src/views/asset-edit-view/layout.tsx
@@ -33,7 +33,7 @@ export const AssetEditLayout = ({
 
   useEffect(() => {
     if (assetDetails.assetAddress.uprn) {
-      console.log("assetDetails.assetAddress.uprn", assetDetails.assetAddress.uprn)
+      console.log("assetDetails.assetAddress.uprn", assetDetails.assetAddress.uprn);
       setLoading(true);
       getAddressViaUprn(assetDetails.assetAddress.uprn)
         .then((searchAddressResponse) => {


### PR DESCRIPTION
- Asset View now displays "Edit address details" button regardless of whether the asset has a UPRN or not
- If the asset has a UPRN, nothing changes, usual behaviour.
- If the asset does not have a UPRN, only one set of editable fields are shown in the "Edit address" page. These are pre-filled with current address details (as in this case no LLPG request is fired).

**Changed behaviour when the LLPG request fails**
When we entered the "Edit address" page previously, for an asset with a UPRN, if the LLPG request failed, we would display the current address read-only fields (on the right) and on the left, we'd display all editable address fields, but blank. This behaviour has been changed to be similar to the non-UPRN edit, meaning that if the LLPG request fails, the read-only "current address" on the right is no longer displayed. Only one set of editable fields is shown, and these, instead of being blank, are pre-populated with the current address's details. The screen would look like "Address without UPRN" screenshot below, with the addition "couldn't fetch LLPG address - manual edit enabled" error on top.

Address without UPRN - Existing address details are loaded into the editable fields.
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/2b17539e-99d5-431e-bd41-7470073e228f)

Address with UPRN (unchanged):
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/e4f577ff-a497-4fe9-b5cd-8cadfdb1f3ad)

