### PR TITLE
MR-735 - Minor improvements to "Related Assets"

### DIFF
--- a/src/components/related-assets/related-assets.tsx
+++ b/src/components/related-assets/related-assets.tsx
@@ -14,12 +14,12 @@ export interface RelatedAssetsProps {
 export const RelatedAssets = ({ assetType, relatedAssets }: RelatedAssetsProps) => {
   const getAssetTypeHeading = () => {
     if (assetType.charAt(assetType.length - 1).toLowerCase() === "s") {
-      return assetType
-    } else if (assetType == "NA") {
-      return "N/A"
-    } else {
-      return `${assetType}s`
+      return assetType;
     }
+    if (assetType == "NA") {
+      return "N/A";
+    }
+    return `${assetType}s`;
   };
 
   const renderRelatedAssets = () => {

--- a/src/components/related-assets/related-assets.tsx
+++ b/src/components/related-assets/related-assets.tsx
@@ -13,9 +13,13 @@ export interface RelatedAssetsProps {
 
 export const RelatedAssets = ({ assetType, relatedAssets }: RelatedAssetsProps) => {
   const getAssetTypeHeading = () => {
-    return assetType.charAt(assetType.length - 1).toLowerCase() === "s"
-      ? assetType
-      : `${assetType}s`;
+    if (assetType.charAt(assetType.length - 1).toLowerCase() === "s") {
+      return assetType
+    } else if (assetType == "NA") {
+      return "N/A"
+    } else {
+      return `${assetType}s`
+    }
   };
 
   const renderRelatedAssets = () => {

--- a/src/components/related-assets/related-assets.tsx
+++ b/src/components/related-assets/related-assets.tsx
@@ -16,7 +16,7 @@ export const RelatedAssets = ({ assetType, relatedAssets }: RelatedAssetsProps) 
     if (assetType.charAt(assetType.length - 1).toLowerCase() === "s") {
       return assetType;
     }
-    if (assetType == "NA") {
+    if (assetType === "NA") {
       return "N/A";
     }
     return `${assetType}s`;

--- a/src/views/related-assets-view/layout.tsx
+++ b/src/views/related-assets-view/layout.tsx
@@ -81,7 +81,7 @@ export const RelatedAssetsLayout = ({
         Related assets
       </h1>
       <p className="lbh-body-m" data-testid="property-asset-type">
-        {asset.assetType == "NA" ? "N/A" : asset.assetType}
+        {asset.assetType === "NA" ? "N/A" : asset.assetType}
       </p>
       <h2 className="lbh-heading-h2 margin-top-10" data-testid="property-address">
         {asset.assetAddress.addressLine1} - {asset.assetAddress.postCode}

--- a/src/views/related-assets-view/layout.tsx
+++ b/src/views/related-assets-view/layout.tsx
@@ -81,7 +81,7 @@ export const RelatedAssetsLayout = ({
         Related assets
       </h1>
       <p className="lbh-body-m" data-testid="property-asset-type">
-        {asset.assetType}
+        {asset.assetType == "NA" ? "N/A" : asset.assetType}
       </p>
       <h2 className="lbh-heading-h2 margin-top-10" data-testid="property-address">
         {asset.assetAddress.addressLine1} - {asset.assetAddress.postCode}

--- a/src/views/related-assets-view/utils.ts
+++ b/src/views/related-assets-view/utils.ts
@@ -35,8 +35,15 @@ const extractAddressNumber = (addressLine1: string) => {
   return match ? parseInt(match[0], 10) : NaN;
 };
 
+const removeHackneyHomesRelatedAsset = (relatedAssets: RelatedAsset[]) => {
+  const hackneyHomesGuid = "656feda1-896f-b136-da84-163ee4f1be6c";
+  return relatedAssets.filter((relatedAsset) =>  relatedAsset.id !=  hackneyHomesGuid)
+}
+
 export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]) => {
   const assetsByType: { [key: string]: RelatedAsset[] } = {};
+
+  relatedAssets = removeHackneyHomesRelatedAsset(relatedAssets);
 
   // Define how many asset types we're dealing with
   const uniqueAssetTypes = new Set<string>([]);
@@ -68,6 +75,18 @@ export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]) => {
       // At least one name doesn't have a number in its addressLine1 (name), sort alphabetically
       return a.name.localeCompare(b.name);
     });
+
+    // removeHackneyHomes(sameTypeAssets)
+
+    // If uniqueAssetTypes include asset type "NA", if "Hackney Homes" is the only asset of this type, ignore this completely
+    console.log("sameTypeAssets", sameTypeAssets)
+    
+    // Check if NA is included in the asset types
+
+    // if ("NA" in sameTypeAssets) {}
+
+    // If yes, check if it contains "Hackney Homes" and no other assets. If yes remove this asset type.
+
 
     // Create new key in object for given AssetType, value will be an array related assets of that type
     assetsByType[uniqueAssetType] = sameTypeAssets;

--- a/src/views/related-assets-view/utils.ts
+++ b/src/views/related-assets-view/utils.ts
@@ -37,8 +37,8 @@ const extractAddressNumber = (addressLine1: string) => {
 
 const removeHackneyHomesRelatedAsset = (relatedAssets: RelatedAsset[]) => {
   const hackneyHomesGuid = "656feda1-896f-b136-da84-163ee4f1be6c";
-  return relatedAssets.filter((relatedAsset) =>  relatedAsset.id !=  hackneyHomesGuid)
-}
+  return relatedAssets.filter((relatedAsset) => relatedAsset.id != hackneyHomesGuid);
+};
 
 export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]) => {
   const assetsByType: { [key: string]: RelatedAsset[] } = {};
@@ -79,14 +79,13 @@ export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]) => {
     // removeHackneyHomes(sameTypeAssets)
 
     // If uniqueAssetTypes include asset type "NA", if "Hackney Homes" is the only asset of this type, ignore this completely
-    console.log("sameTypeAssets", sameTypeAssets)
-    
+    console.log("sameTypeAssets", sameTypeAssets);
+
     // Check if NA is included in the asset types
 
     // if ("NA" in sameTypeAssets) {}
 
     // If yes, check if it contains "Hackney Homes" and no other assets. If yes remove this asset type.
-
 
     // Create new key in object for given AssetType, value will be an array related assets of that type
     assetsByType[uniqueAssetType] = sameTypeAssets;

--- a/src/views/related-assets-view/utils.ts
+++ b/src/views/related-assets-view/utils.ts
@@ -37,7 +37,7 @@ const extractAddressNumber = (addressLine1: string) => {
 
 const removeHackneyHomesRelatedAsset = (relatedAssets: RelatedAsset[]) => {
   const hackneyHomesGuid = "656feda1-896f-b136-da84-163ee4f1be6c";
-  return relatedAssets.filter((relatedAsset) => relatedAsset.id != hackneyHomesGuid);
+  return relatedAssets.filter((relatedAsset) => relatedAsset.id !== hackneyHomesGuid);
 };
 
 export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]) => {

--- a/src/views/related-assets-view/utils.ts
+++ b/src/views/related-assets-view/utils.ts
@@ -76,17 +76,6 @@ export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]) => {
       return a.name.localeCompare(b.name);
     });
 
-    // removeHackneyHomes(sameTypeAssets)
-
-    // If uniqueAssetTypes include asset type "NA", if "Hackney Homes" is the only asset of this type, ignore this completely
-    console.log("sameTypeAssets", sameTypeAssets);
-
-    // Check if NA is included in the asset types
-
-    // if ("NA" in sameTypeAssets) {}
-
-    // If yes, check if it contains "Hackney Homes" and no other assets. If yes remove this asset type.
-
     // Create new key in object for given AssetType, value will be an array related assets of that type
     assetsByType[uniqueAssetType] = sameTypeAssets;
   });


### PR DESCRIPTION
Problem:
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/af9f5a76-3645-4dad-84f8-3b89732eb58c)

Fix:
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/c02272ff-9cd5-4c9a-891f-bedd0bda546f)

- Any asset of type `"NA"`, is currently shown under `"NAs"`, with an s at the end for its plural form, not applicable here obviously. A change has been made so that if there are assets of type `"NA"`, no final s is added, and the asset type is visualised as `"N/A"` (presumably "Not Available/Applicable").

- The same applies for the asset type, displayed above the current asset type.

- Hackney Homes has been removed from Related Assets, as no user would ever need to navigate to "Hackney Homes" for any useful reason. It would also seem that if a user does try to go on the "Related asset" page for Hackney Homes, the data shown isn't exactly correct (https://manage-my-home.hackney.gov.uk/property/related/656feda1-896f-b136-da84-163ee4f1be6c)