### PR TITLE
MR-733 - Removed Asset Type limitation from view

### DIFF
--- a/src/views/asset-edit-view/asset-edit-view.tsx
+++ b/src/views/asset-edit-view/asset-edit-view.tsx
@@ -46,11 +46,7 @@ export const AssetEditView = (): JSX.Element => {
 
   return (
     <>
-      {asset.assetType === "Dwelling" || asset.assetType === "LettableNonDwelling" ? (
-        <AssetEditLayout assetDetails={asset} tenureApiObject={tenure} />
-      ) : (
-        <h1>{locale.assetCouldNotBeLoaded}</h1>
-      )}
+      <AssetEditLayout assetDetails={asset} tenureApiObject={tenure} />
     </>
   );
 };


### PR DESCRIPTION
Removed Asset Type limitation, which was causing non Dwelling/LettableNonDwelling properties not to load in Edit Address page