### PR TITLE
MR-734 - New Asset form - Only one parent asset can be added to a new asset

### DIFF
--- a/src/components/inline-asset-search/inline-asset-search.tsx
+++ b/src/components/inline-asset-search/inline-asset-search.tsx
@@ -38,7 +38,7 @@ export const InlineAssetSearch = ({
     ...(searchResultsData?.map((x) => ({
       value: x.id,
       label: x.assetAddress.addressLine1,
-      assetType: x.assetType
+      assetType: x.assetType,
     })) || []),
   ];
 

--- a/src/components/inline-asset-search/inline-asset-search.tsx
+++ b/src/components/inline-asset-search/inline-asset-search.tsx
@@ -38,6 +38,7 @@ export const InlineAssetSearch = ({
     ...(searchResultsData?.map((x) => ({
       value: x.id,
       label: x.assetAddress.addressLine1,
+      assetType: x.assetType
     })) || []),
   ];
 
@@ -90,7 +91,7 @@ export const InlineAssetSearch = ({
             >
               <>
                 {options.map((x, i) => (
-                  <option key={i} value={x.value}>
+                  <option key={i} value={JSON.stringify(x)}>
                     {x.label}
                   </option>
                 ))}

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -122,8 +122,7 @@ export const NewAsset = ({
         initialValues={{
           assetId: "",
           assetType: "",
-          propertyEstate: "",
-          propertyBlock: "",
+          parentAsset: "",
           floorNo: "",
           totalBlockFloors: undefined,
           uprn: "",
@@ -166,7 +165,7 @@ export const NewAsset = ({
                 }
               >
                 <label className="govuk-label lbh-label" htmlFor="assetId">
-                  Asset ID
+                  Asset ID*
                 </label>
                 {errors.assetId && touched.assetId && (
                   <span
@@ -199,7 +198,7 @@ export const NewAsset = ({
                 }
               >
                 <label className="govuk-label lbh-label" htmlFor="assetType">
-                  Asset Type
+                  Asset type*
                 </label>
                 {errors.assetType && touched.assetType && (
                   <span
@@ -233,26 +232,14 @@ export const NewAsset = ({
                   {renderAssetTypeOptions()}
                 </Field>
               </div>
-              {values.assetType !== "Estate" && (
-                <InlineAssetSearch
-                  assetTypes={["Estate"]}
-                  name="propertyEstate"
-                  label="Estate this property is in"
-                  onChange={handleChange}
-                  setFieldValue={setFieldValue}
-                  value={values.propertyEstate || ""}
-                />
-              )}
-              {values.assetType !== "Block" && values.assetType !== "Estate" && (
-                <InlineAssetSearch
-                  assetTypes={["Block"]}
-                  name="propertyBlock"
-                  label="Block this property is in"
-                  onChange={handleChange}
-                  setFieldValue={setFieldValue}
-                  value={values.propertyBlock || ""}
-                />
-              )}
+              <InlineAssetSearch
+                assetTypes={[]}
+                name="parentAsset"
+                label="Parent asset"
+                onChange={handleChange}
+                setFieldValue={setFieldValue}
+                value={values.parentAsset || ""}
+              />
               {assetHasFloorNo(values.assetType) && (
                 <>
                   <label className="govuk-label lbh-label" htmlFor="floor-no">
@@ -333,7 +320,7 @@ export const NewAsset = ({
                 }
               >
                 <label className="govuk-label lbh-label" htmlFor="address-line-1">
-                  Address line 1
+                  Address line 1*
                 </label>
                 {errors.addressLine1 && touched.addressLine1 && (
                   <span
@@ -396,7 +383,7 @@ export const NewAsset = ({
                 }
               >
                 <label className="govuk-label lbh-label" htmlFor="postcode">
-                  Postcode
+                  Postcode*
                 </label>
                 {errors.postcode && touched.postcode && (
                   <span
@@ -622,7 +609,7 @@ export const NewAsset = ({
                 }
               >
                 <fieldset className="govuk-fieldset">
-                  <legend className="govuk-label lbh-label">Is LBH property?</legend>
+                  <legend className="govuk-label lbh-label">Is LBH property?*</legend>
                   {errors.isCouncilProperty && touched.isCouncilProperty && (
                     <span
                       id="is-lbh-property-error"
@@ -681,7 +668,7 @@ export const NewAsset = ({
                 }
               >
                 <label className="govuk-label lbh-label" htmlFor="managing-organisation">
-                  Managing organisation
+                  Managing organisation*
                 </label>
                 {errors.managingOrganisation && touched.managingOrganisation && (
                   <span

--- a/src/components/new-asset-form/patches-field.tsx
+++ b/src/components/new-asset-form/patches-field.tsx
@@ -40,15 +40,14 @@ export const PatchesField = ({
     if (patchesAndAreasData.length) {
       const patches = patchesState.patches.map((patch: PropertyPatch) => {
         return (
-          <>
-            <div className="patch" key={patch.id}>
+          <React.Fragment key={patch.id}>
+            <div className="patch">
               <Field
                 as="select"
                 id={`patch-dropdown-${patch.id}`}
                 className="govuk-input lbh-input"
                 data-testid={`patch-dropdown-${patch.id}`}
                 value={patch.value}
-                key={`patch-dropdown-${patch.id}`}
                 onChange={(e: any) => handlePatchEdit(e, patch.id)}
               >
                 <option disabled value="">
@@ -62,12 +61,11 @@ export const PatchesField = ({
                 onClick={(e) => handleRemovePatch(e, patch.id)}
                 data-testid={`patch-remove-link-${patch.id}`}
                 id={`patch-remove-link-${patch.id}`}
-                key={`patch-remove-link-${patch.id}`}
               >
                 Remove patch
               </button>
             </div>
-          </>
+          </React.Fragment>
         );
       });
       return patches;

--- a/src/components/new-asset-form/patches-field.tsx
+++ b/src/components/new-asset-form/patches-field.tsx
@@ -40,32 +40,30 @@ export const PatchesField = ({
     if (patchesAndAreasData.length) {
       const patches = patchesState.patches.map((patch: PropertyPatch) => {
         return (
-          <React.Fragment key={patch.id}>
-            <div className="patch">
-              <Field
-                as="select"
-                id={`patch-dropdown-${patch.id}`}
-                className="govuk-input lbh-input"
-                data-testid={`patch-dropdown-${patch.id}`}
-                value={patch.value}
-                onChange={(e: any) => handlePatchEdit(e, patch.id)}
-              >
-                <option disabled value="">
-                  {" "}
-                  -- Select an option --{" "}
-                </option>
-                {renderPatchOptions()}
-              </Field>
-              <button
-                className="lbh-link patch-remove-link"
-                onClick={(e) => handleRemovePatch(e, patch.id)}
-                data-testid={`patch-remove-link-${patch.id}`}
-                id={`patch-remove-link-${patch.id}`}
-              >
-                Remove patch
-              </button>
-            </div>
-          </React.Fragment>
+          <div className="patch" key={patch.id}>
+            <Field
+              as="select"
+              id={`patch-dropdown-${patch.id}`}
+              className="govuk-input lbh-input"
+              data-testid={`patch-dropdown-${patch.id}`}
+              value={patch.value}
+              onChange={(e: any) => handlePatchEdit(e, patch.id)}
+            >
+              <option disabled value="">
+                {" "}
+                -- Select an option --{" "}
+              </option>
+              {renderPatchOptions()}
+            </Field>
+            <button
+              className="lbh-link patch-remove-link"
+              onClick={(e) => handleRemovePatch(e, patch.id)}
+              data-testid={`patch-remove-link-${patch.id}`}
+              id={`patch-remove-link-${patch.id}`}
+            >
+              Remove patch
+            </button>
+          </div>
         );
       });
       return patches;

--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -8,8 +8,7 @@ export const newPropertySchema = () =>
   Yup.object({
     assetId: Yup.string().required("Asset ID is a required field"),
     assetType: Yup.string().required("Asset Type is a required field"),
-    propertyEstate: Yup.string(),
-    propertyBlock: Yup.string(),
+    parentAsset: Yup.string(),
     floorNo: Yup.string(),
     totalBlockFloors: Yup.number()
       .nullable()

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -10,18 +10,17 @@ export const assembleCreateNewAssetRequest = (
   values: NewPropertyFormData,
   patches: Patch[],
 ) => {
-  const parentAssetIds: string[] = getParentAssetsIds(values);
 
   const asset: CreateNewAssetRequest = {
     id: uuidv4(),
     assetId: values.assetId,
     assetType: values.assetType,
-    parentAssetIds: parentAssetIds.join("#"),
+    parentAssetIds: values?.parentAsset ? JSON.parse(values?.parentAsset).value : "",
     isActive: true,
     assetLocation: {
       floorNo: values?.floorNo ?? "",
       totalBlockFloors: values?.totalBlockFloors ?? null,
-      parentAssets: [],
+      parentAssets: values?.parentAsset ? [JSON.parse(values?.parentAsset)] : [],
     },
     assetAddress: {
       uprn: values?.uprn ?? "",
@@ -58,14 +57,4 @@ const getManagingOrganisationId = (managingOrganisation: string) => {
     (org) => org.managingOrganisation === managingOrganisation,
   );
   return match ? match.managingOrganisationId : "";
-};
-
-const getParentAssetsIds = (formValues: NewPropertyFormData) => {
-  const parentAssetIds = [];
-  if (formValues?.propertyEstate && formValues.propertyEstate !== "")
-    parentAssetIds.push(formValues.propertyEstate);
-  if (formValues?.propertyBlock && formValues.propertyBlock !== "")
-    parentAssetIds.push(formValues.propertyBlock);
-
-  return parentAssetIds;
 };

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import { NewPropertyFormData } from "../components/new-asset-form/schema";
 import { managingOrganisations } from "../components/new-asset-form/utils/managing-organisations";
 
-import { CreateNewAssetRequest } from "@mtfh/common/lib/api/asset/v1";
+import { CreateNewAssetRequest, ParentAsset } from "@mtfh/common/lib/api/asset/v1";
 import { Patch } from "@mtfh/common/lib/api/patch/v1/types";
 
 export const assembleCreateNewAssetRequest = (
@@ -15,12 +15,12 @@ export const assembleCreateNewAssetRequest = (
     id: uuidv4(),
     assetId: values.assetId,
     assetType: values.assetType,
-    parentAssetIds: values?.parentAsset ? JSON.parse(values?.parentAsset).value : "",
+    parentAssetIds: values?.parentAsset ? getParentAsset(values?.parentAsset).id : "",
     isActive: true,
     assetLocation: {
       floorNo: values?.floorNo ?? "",
       totalBlockFloors: values?.totalBlockFloors ?? null,
-      parentAssets: values?.parentAsset ? [JSON.parse(values?.parentAsset)] : [],
+      parentAssets: values?.parentAsset ? [getParentAsset(values?.parentAsset)] : [],
     },
     assetAddress: {
       uprn: values?.uprn ?? "",
@@ -58,3 +58,15 @@ const getManagingOrganisationId = (managingOrganisation: string) => {
   );
   return match ? match.managingOrganisationId : "";
 };
+
+const getParentAsset = (parentAsset: string): ParentAsset => {
+  // Convert the value from the Parent Asset field from JSON back into an object
+  const parentAssetObject = JSON.parse(parentAsset);
+
+  // Use its values to output a new object of the type (ParentAsset) with the correct properties
+  return {
+    id: parentAssetObject.value,
+    name: parentAssetObject.label,
+    type: parentAssetObject.assetType
+  }
+}

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -10,7 +10,6 @@ export const assembleCreateNewAssetRequest = (
   values: NewPropertyFormData,
   patches: Patch[],
 ) => {
-
   const asset: CreateNewAssetRequest = {
     id: uuidv4(),
     assetId: values.assetId,
@@ -67,6 +66,6 @@ const getParentAsset = (parentAsset: string): ParentAsset => {
   return {
     id: parentAssetObject.value,
     name: parentAssetObject.label,
-    type: parentAssetObject.assetType
-  }
-}
+    type: parentAssetObject.assetType,
+  };
+};

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
             class="govuk-label lbh-label"
             for="assetId"
           >
-            Asset ID
+            Asset ID*
           </label>
           <input
             class="govuk-input lbh-input"
@@ -53,7 +53,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
             class="govuk-label lbh-label"
             for="assetType"
           >
-            Asset Type
+            Asset type*
           </label>
           <select
             class="govuk-input lbh-input"
@@ -214,9 +214,9 @@ exports[`renders the whole 'New asset form' view 1`] = `
         >
           <label
             class="govuk-label lbh-label"
-            for="propertyEstate"
+            for="parentAsset"
           >
-            Estate this property is in
+            Parent asset
           </label>
           <div
             class=""
@@ -242,61 +242,14 @@ exports[`renders the whole 'New asset form' view 1`] = `
           >
             <select
               class="govuk-input lbh-input"
-              data-testid="propertyEstate"
+              data-testid="parentAsset"
               disabled=""
-              id="propertyEstate"
-              name="propertyEstate"
+              id="parentAsset"
+              name="parentAsset"
               style="max-width: 100%;"
             >
               <option
-                value=""
-              >
-                -- Select an option --
-              </option>
-            </select>
-          </div>
-        </div>
-        <div
-          style="border-left: 5px solid #0b0c0c; padding-left: 30px; width: 500px; box-sizing: border-box;"
-        >
-          <label
-            class="govuk-label lbh-label"
-            for="propertyBlock"
-          >
-            Block this property is in
-          </label>
-          <div
-            class=""
-          >
-            <div
-              class="govuk-form-group  lbh-form-group visually-hidden-label"
-            >
-              <input
-                class="govuk-input lbh-input"
-                style="max-width: 100%;"
-                value=""
-              />
-            </div>
-            <button
-              class="govuk-button lbh-button"
-              type="button"
-            >
-              Search
-            </button>
-          </div>
-          <div
-            class="govuk-form-group lbh-form-group"
-          >
-            <select
-              class="govuk-input lbh-input"
-              data-testid="propertyBlock"
-              disabled=""
-              id="propertyBlock"
-              name="propertyBlock"
-              style="max-width: 100%;"
-            >
-              <option
-                value=""
+                value="{\\"value\\":\\"\\",\\"label\\":\\"-- Select an option --\\"}"
               >
                 -- Select an option --
               </option>
@@ -341,7 +294,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
             class="govuk-label lbh-label"
             for="address-line-1"
           >
-            Address line 1
+            Address line 1*
           </label>
           <input
             class="govuk-input lbh-input"
@@ -398,7 +351,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
             class="govuk-label lbh-label"
             for="postcode"
           >
-            Postcode
+            Postcode*
           </label>
           <input
             class="govuk-input lbh-input"
@@ -663,7 +616,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
             <legend
               class="govuk-label lbh-label"
             >
-              Is LBH property?
+              Is LBH property?*
             </legend>
             <div
               class="govuk-radios lbh-radios"
@@ -714,7 +667,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
             class="govuk-label lbh-label"
             for="managing-organisation"
           >
-            Managing organisation
+            Managing organisation*
           </label>
           <select
             class="govuk-input lbh-input"

--- a/src/views/new-asset-view/layout.tsx
+++ b/src/views/new-asset-view/layout.tsx
@@ -14,17 +14,6 @@ export const NewPropertyLayout = (): JSX.Element => {
   const [errorHeading, setErrorHeading] = useState<string | null>(null);
   const [errorDescription, setErrorDescription] = useState<string | null>(null);
 
-  const renderNewPropertyLink = () => {
-    return (
-      <div>
-        {" "}
-        <Link as={RouterLink} to={`/property/${newProperty?.id}`}>
-          View property
-        </Link>{" "}
-      </div>
-    );
-  };
-
   return (
     <>
       <Link as={RouterLink} to="#" variant="back-link">
@@ -43,7 +32,12 @@ export const NewPropertyLayout = (): JSX.Element => {
       </span>
       {showSuccess && (
         <StatusBox variant="success" title={locale.assets.newPropertyAddedSuccessMessage}>
-          {renderNewPropertyLink()}
+          <div>
+            {" "}
+            <Link as={RouterLink} to={`/property/${newProperty?.id}`}>
+              View property
+            </Link>{" "}
+          </div>
         </StatusBox>
       )}
 

--- a/src/views/new-asset-view/layout.tsx
+++ b/src/views/new-asset-view/layout.tsx
@@ -16,16 +16,12 @@ export const NewPropertyLayout = (): JSX.Element => {
 
   const renderNewPropertyLink = () => {
     return (
-      // Only include link if visible on MMH
-      (newProperty?.assetType === "Dwelling" ||
-        newProperty?.assetType === "LettableNonDwelling") && (
-        <div>
-          {" "}
-          <Link as={RouterLink} to={`/property/${newProperty?.id}`}>
-            View property
-          </Link>{" "}
-        </div>
-      )
+      <div>
+        {" "}
+        <Link as={RouterLink} to={`/property/${newProperty?.id}`}>
+          View property
+        </Link>{" "}
+      </div>
     );
   };
 

--- a/src/views/related-assets-view/__snapshots__/related-assets-view.test.tsx.snap
+++ b/src/views/related-assets-view/__snapshots__/related-assets-view.test.tsx.snap
@@ -32,72 +32,76 @@ exports[`it renders the component 1`] = `
     style="border-top: 1px solid #e7eaec;"
   />
   <section>
-    <p
-      class="lbh-body-m"
-    >
-      Estates
-    </p>
-    <div
-      class="mtfh-card-list"
-      data-testid="related-asset-items-group"
-    >
+    <section>
+      <p
+        class="lbh-body-m"
+      >
+        Estates
+      </p>
       <div
-        class="mtfh-link-box"
-        data-testid="related-asset"
+        class="mtfh-card-list"
+        data-testid="related-asset-items-group"
       >
         <div
-          class="mtfh-search-card"
+          class="mtfh-link-box"
+          data-testid="related-asset"
         >
           <div
-            class="mtfh-link-overlay"
+            class="mtfh-search-card"
           >
-            <a
-              class="govuk-link lbh-link lbh-link--text-colour lbh-link--no-visited-state mtfh-search-tenure__title"
-              href="/property/14edf718-19ff-ff43-4679-f8ef404fa029"
+            <div
+              class="mtfh-link-overlay"
             >
-              Frampton Park Estate Frampton Park Road
-            </a>
+              <a
+                class="govuk-link lbh-link lbh-link--text-colour lbh-link--no-visited-state mtfh-search-tenure__title"
+                href="/property/14edf718-19ff-ff43-4679-f8ef404fa029"
+              >
+                Frampton Park Estate Frampton Park Road
+              </a>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
+    <hr
+      style="border-top: 1px solid #e7eaec;"
+    />
   </section>
-  <hr
-    style="border-top: 1px solid #e7eaec;"
-  />
   <section>
-    <p
-      class="lbh-body-m"
-    >
-      Dwellings
-    </p>
-    <div
-      class="mtfh-card-list"
-      data-testid="related-asset-items-group"
-    >
+    <section>
+      <p
+        class="lbh-body-m"
+      >
+        Dwellings
+      </p>
       <div
-        class="mtfh-link-box"
-        data-testid="related-asset"
+        class="mtfh-card-list"
+        data-testid="related-asset-items-group"
       >
         <div
-          class="mtfh-search-card"
+          class="mtfh-link-box"
+          data-testid="related-asset"
         >
           <div
-            class="mtfh-link-overlay"
+            class="mtfh-search-card"
           >
-            <a
-              class="govuk-link lbh-link lbh-link--text-colour lbh-link--no-visited-state mtfh-search-tenure__title"
-              href="/property/13e7cf17-60a0-729d-c297-a4e76a16b6fa"
+            <div
+              class="mtfh-link-overlay"
             >
-              61 PITCAIRN HOUSE
-            </a>
+              <a
+                class="govuk-link lbh-link lbh-link--text-colour lbh-link--no-visited-state mtfh-search-tenure__title"
+                href="/property/13e7cf17-60a0-729d-c297-a4e76a16b6fa"
+              >
+                61 PITCAIRN HOUSE
+              </a>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
+    <hr
+      style="border-top: 1px solid #e7eaec;"
+    />
   </section>
-  <hr
-    style="border-top: 1px solid #e7eaec;"
-  />
 </div>
 `;

--- a/src/views/related-assets-view/layout.tsx
+++ b/src/views/related-assets-view/layout.tsx
@@ -26,7 +26,7 @@ export const RelatedAssetsLayout = ({
   const [relatedAssetsByType, setRelatedAssetsByType] = useState<any>(undefined);
 
   useEffect(() => {
-    if (parentAssets && parentAssets.length && childrenAssets) {
+    if (parentAssets && parentAssets.length || childrenAssets) {
       setRelatedAssets(getAllRelatedAssets(parentAssets, childrenAssets));
     }
   }, [parentAssets, childrenAssets]);

--- a/src/views/related-assets-view/layout.tsx
+++ b/src/views/related-assets-view/layout.tsx
@@ -55,13 +55,13 @@ export const RelatedAssetsLayout = ({
     if (assetHasRelatedAssets() && relatedAssetsByType) {
       return Object.keys(relatedAssetsByType).map((assetType) => {
         return (
-          <React.Fragment key={assetType}>
+          <section key={assetType}>
             <RelatedAssets
               assetType={assetType}
               relatedAssets={relatedAssetsByType[assetType]}
             />
             <hr style={{ borderTop: "1px solid #e7eaec" }} />
-          </React.Fragment>
+          </section>
         );
       });
     }

--- a/src/views/related-assets-view/layout.tsx
+++ b/src/views/related-assets-view/layout.tsx
@@ -26,7 +26,7 @@ export const RelatedAssetsLayout = ({
   const [relatedAssetsByType, setRelatedAssetsByType] = useState<any>(undefined);
 
   useEffect(() => {
-    if (parentAssets && parentAssets.length || childrenAssets) {
+    if ((parentAssets && parentAssets.length) || childrenAssets) {
       setRelatedAssets(getAllRelatedAssets(parentAssets, childrenAssets));
     }
   }, [parentAssets, childrenAssets]);

--- a/src/views/related-assets-view/utils.ts
+++ b/src/views/related-assets-view/utils.ts
@@ -35,7 +35,6 @@ const extractAddressNumber = (addressLine1: string) => {
   return match ? parseInt(match[0], 10) : NaN;
 };
 
-
 const removeHackneyHomesRelatedAsset = (relatedAssets: RelatedAsset[]) => {
   const hackneyHomesGuid = "656feda1-896f-b136-da84-163ee4f1be6c";
   return relatedAssets.filter((relatedAsset) => relatedAsset.id !== hackneyHomesGuid);

--- a/src/views/related-assets-view/utils.ts
+++ b/src/views/related-assets-view/utils.ts
@@ -73,10 +73,6 @@ export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]) => {
     assetsByType[uniqueAssetType] = sameTypeAssets;
   });
 
-  // Sort items by addressLine1
-
-  console.log("assetsByType", assetsByType);
-
   // Return an object that contains multiple arrays of RelatedAsset[]
   return assetsByType;
 };

--- a/src/views/related-assets-view/utils.ts
+++ b/src/views/related-assets-view/utils.ts
@@ -35,7 +35,7 @@ const extractAddressNumber = (addressLine1: string) => {
   return match ? parseInt(match[0], 10) : NaN;
 };
 
-export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]) => {
+export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]): Object => {
   const assetsByType: { [key: string]: RelatedAsset[] } = {};
 
   // Define how many asset types we're dealing with

--- a/src/views/related-assets-view/utils.ts
+++ b/src/views/related-assets-view/utils.ts
@@ -35,8 +35,16 @@ const extractAddressNumber = (addressLine1: string) => {
   return match ? parseInt(match[0], 10) : NaN;
 };
 
+
+const removeHackneyHomesRelatedAsset = (relatedAssets: RelatedAsset[]) => {
+  const hackneyHomesGuid = "656feda1-896f-b136-da84-163ee4f1be6c";
+  return relatedAssets.filter((relatedAsset) => relatedAsset.id !== hackneyHomesGuid);
+};
+
 export const organiseRelatedAssetsByType = (relatedAssets: RelatedAsset[]): Object => {
   const assetsByType: { [key: string]: RelatedAsset[] } = {};
+
+  relatedAssets = removeHackneyHomesRelatedAsset(relatedAssets);
 
   // Define how many asset types we're dealing with
   const uniqueAssetTypes = new Set<string>([]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,7 +1510,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#02d620e845da5c18b9c8a9fc7fe4d5385112fea7"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#f21d06a5bbb019449fd9c662961345a785b543b1"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"
@@ -1543,7 +1543,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#02d620e845da5c18b9c8a9fc7fe4d5385112fea7"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#f21d06a5bbb019449fd9c662961345a785b543b1"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,7 +1510,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#f21d06a5bbb019449fd9c662961345a785b543b1"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#3a7a76f84ca818d48f7ef9b819f9f86b41d4cdc8"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"
@@ -1543,7 +1543,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#f21d06a5bbb019449fd9c662961345a785b543b1"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#3a7a76f84ca818d48f7ef9b819f9f86b41d4cdc8"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"


### PR DESCRIPTION
### **Main changes:**

**Issue:**
Prior to this PR, "Edit address" feature would allow the user to **optionally** add up to 2 parents, specifically "Estate" and "Block". Once these related asset were added using the form, these would eventually populate the `asset.parentAssetIds` field of the new asset with one or more GUIDs (separated by `#`).

**Resolution:** 
"Estate" and "Block" fields, which where conditionally shown (based on the asset type being added), have been replaced by one (still optional) "Parent asset" field, which is always visible. This allows the user to link the asset that's being created, to one single parent asset (of any asset type).

Now not only the field `asset.parentAssetIds` is updated, with one single GUID belonging to the chosen parent asset, but the parent asset is also added to the `asset.assetLocation.parentAssets` field of the new asset (see screenshot).

![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/7ac88ee3-9282-4e18-9fa9-1f335bcee999)

### **Additional changes/fixes to "Related Asset View":**

- Bugfix: If the asset had existing children, these would only be shown in "Related Asset" view if the asset also had a parent, otherwise they would not be shown at all, and the message "This asset has no related asset" would be shown. This bug has been fixed, so that the asset can have either a parent or children asset or both, and regardless, related assets are shown.

- Change: "Hackney Homes" has been removed from Related Assets, as no user would ever need to navigate to "Hackney Homes" for any useful reason. It would also seem that if a user does try to go on the "Related asset" page for Hackney Homes, the data shown isn't exactly correct (https://manage-my-home.hackney.gov.uk/property/related/656feda1-896f-b136-da84-163ee4f1be6c)