### PR TITLE
MR-516 Add option to add default SOR contracts

### DIFF
--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -707,7 +707,9 @@ export const NewAsset = ({
                 }
               >
                 <fieldset className="govuk-fieldset">
-                  <legend className="govuk-label lbh-label">Are Repairs being raised to this Asset?*</legend>
+                  <legend className="govuk-label lbh-label">
+                    Are Repairs being raised to this Asset?*
+                  </legend>
                   {errors.addDefaultSorContracts && touched.addDefaultSorContracts && (
                     <span
                       id="is-lbh-sor-contract-error"

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -134,6 +134,7 @@ export const NewAsset = ({
           numberOfLifts: undefined,
           windowType: "",
           yearConstructed: undefined,
+          addDefaultSorContracts: "",
         }}
         validationSchema={newPropertySchema}
         onSubmit={(values) => handleSubmit(values)}
@@ -697,6 +698,65 @@ export const NewAsset = ({
                   </option>
                   {renderManagingOrganisationOptions()}
                 </Field>
+              </div>
+              <div
+                className={
+                  errors.addDefaultSorContracts && touched.addDefaultSorContracts
+                    ? "govuk-form-group govuk-form-group--error lbh-form-group"
+                    : "govuk-form-group lbh-form-group"
+                }
+              >
+                <fieldset className="govuk-fieldset">
+                  <legend className="govuk-label lbh-label">Are Repairs being raised to this Asset?*</legend>
+                  {errors.addDefaultSorContracts && touched.addDefaultSorContracts && (
+                    <span
+                      id="is-lbh-sor-contract-error"
+                      className="govuk-error-message lbh-error-message"
+                    >
+                      <span
+                        className="govuk-visually-hidden"
+                        data-testid="error-add-default-sor-contracts"
+                      >
+                        Error:
+                      </span>{" "}
+                      {errors.addDefaultSorContracts}
+                    </span>
+                  )}
+                  <div className="govuk-radios lbh-radios">
+                    <div className="govuk-radios__item">
+                      <Field
+                        className="govuk-radios__input"
+                        id="add-default-sor-contracts-yes"
+                        name="addDefaultSorContracts"
+                        type="radio"
+                        value="Yes"
+                        data-testid="add-default-sor-contracts-yes"
+                      />
+                      <label
+                        className="govuk-label govuk-radios__label"
+                        htmlFor="add-default-sor-contracts-yes"
+                      >
+                        Yes, add DLO contracts to the Asset
+                      </label>
+                    </div>
+                    <div className="govuk-radios__item">
+                      <Field
+                        className="govuk-radios__input"
+                        id="add-default-sor-contracts-no"
+                        name="addDefaultSorContracts"
+                        type="radio"
+                        value="No"
+                        data-testid="add-default-sor-contracts-no"
+                      />
+                      <label
+                        className="govuk-label govuk-radios__label"
+                        htmlFor="add-default-sor-contracts-no"
+                      >
+                        No
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
               </div>
               <div className="new-property-form-actions">
                 {!isValid && submitCount > 0 && (

--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -42,7 +42,7 @@ export const newPropertySchema = () =>
         }),
       )
       .nullable(),
-    
+
     addDefaultSorContracts: Yup.string().required("Please select an option"),
 
     // Asset details

--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -42,6 +42,8 @@ export const newPropertySchema = () =>
         }),
       )
       .nullable(),
+    
+    addDefaultSorContracts: Yup.string().required("Please select an option"),
 
     // Asset details
     numberOfBedrooms: Yup.number()

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -46,7 +46,7 @@ export const assembleCreateNewAssetRequest = (
       numberOfLifts: values?.numberOfLifts ?? null,
     },
     patches: patches.length ? patches : undefined,
-    addDefaultSorContracts: values?.addDefaultSorContracts === "Yes"
+    addDefaultSorContracts: values?.addDefaultSorContracts === "Yes",
   };
 
   return asset;

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -46,6 +46,7 @@ export const assembleCreateNewAssetRequest = (
       numberOfLifts: values?.numberOfLifts ?? null,
     },
     patches: patches.length ? patches : undefined,
+    addDefaultSorContracts: values?.addDefaultSorContracts === "Yes"
   };
 
   return asset;

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -724,6 +724,59 @@ exports[`renders the whole 'New asset form' view 1`] = `
           </select>
         </div>
         <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <fieldset
+            class="govuk-fieldset"
+          >
+            <legend
+              class="govuk-label lbh-label"
+            >
+              Are Repairs being raised to this Asset?*
+            </legend>
+            <div
+              class="govuk-radios lbh-radios"
+            >
+              <div
+                class="govuk-radios__item"
+              >
+                <input
+                  class="govuk-radios__input"
+                  data-testid="add-default-sor-contracts-yes"
+                  id="add-default-sor-contracts-yes"
+                  name="addDefaultSorContracts"
+                  type="radio"
+                  value="Yes"
+                />
+                <label
+                  class="govuk-label govuk-radios__label"
+                  for="add-default-sor-contracts-yes"
+                >
+                  Yes, add DLO contracts to the Asset
+                </label>
+              </div>
+              <div
+                class="govuk-radios__item"
+              >
+                <input
+                  class="govuk-radios__input"
+                  data-testid="add-default-sor-contracts-no"
+                  id="add-default-sor-contracts-no"
+                  name="addDefaultSorContracts"
+                  type="radio"
+                  value="No"
+                />
+                <label
+                  class="govuk-label govuk-radios__label"
+                  for="add-default-sor-contracts-no"
+                >
+                  No
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div
           class="new-property-form-actions"
         >
           <button


### PR DESCRIPTION
Jira: https://hackney.atlassian.net/browse/MR-516

- When adding properties, we'd like to know whether we can add the default DLO contracts to them
- Backend implementation TBC but ideally it would form part of the SNS message, listened to by Asset listener and migrated in to RH DB
- The request generator is well tested already, updating the snapshot will do for this
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/8542878/69e907d6-7855-4542-894c-f74cdaf4d0c9)
