### PR TITLE
New Asset form - Postcode case sensitivity

### DIFF
--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -25,6 +25,7 @@ export const newPropertySchema = () =>
       .trim()
       .transform(removeWhitespace)
       .required("Postcode is a required field")
+      .uppercase()
       .matches(regexUkPostcode, "Please enter a valid postcode"),
 
     // Property management

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -28,7 +28,7 @@ export const assembleCreateNewAssetRequest = (
       addressLine2: values?.addressLine2 ?? "",
       addressLine3: values?.addressLine3 ?? "",
       addressLine4: values?.addressLine4 ?? "",
-      postCode: values.postcode,
+      postCode: values.postcode.toUpperCase(),
     },
     assetManagement: {
       agent: values?.agent ?? "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,7 +1510,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#9976456a441cfeca967e13124cbecc10507c074e"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#637520a45508e3606b3f190457f956c8f8e71497"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"
@@ -1543,7 +1543,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#9976456a441cfeca967e13124cbecc10507c074e"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#637520a45508e3606b3f190457f956c8f8e71497"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"


### PR DESCRIPTION
At the moment the Postcode field of the New Asset form does not accept lower case inputs.

This PR changes the following:
- Postcode field now accepts lower case inputs too. 
- Regardless of case, the input is converted to upper case and validated against the same regex. 
- Regardless of case, the input is converted to upper case when the CreateNewAssetRequest object is assembled (to ensure consistency). 

Other changes:
- Common MFE commit hash in yarn.lock file has been updated with the latest