### PR TITLE
Production bug fix - Cannot create new asset with parent asset

### DIFF
--- a/src/components/inline-asset-search/inline-asset-search.tsx
+++ b/src/components/inline-asset-search/inline-asset-search.tsx
@@ -67,6 +67,7 @@ export const InlineAssetSearch = ({
       <InlineSearchForm
         loading={loading}
         onSubmit={(searchText) => handleSubmit(searchText)}
+        fieldName={name}
       />
 
       {loading ? (

--- a/src/components/inline-asset-search/inline-asset-search.tsx
+++ b/src/components/inline-asset-search/inline-asset-search.tsx
@@ -91,7 +91,7 @@ export const InlineAssetSearch = ({
             >
               <>
                 {options.map((x, i) => (
-                  <option key={i} value={x.value}>
+                  <option key={i} value={JSON.stringify(x)}>
                     {x.label}
                   </option>
                 ))}

--- a/src/components/inline-search-form/inline-search-form.tsx
+++ b/src/components/inline-search-form/inline-search-form.tsx
@@ -8,10 +8,11 @@ interface Props {
   onSubmit: (searchText: string) => void;
   className?: string;
   loading: boolean;
+  fieldName: string;
 }
 
 // Cant use form tags inside existing form
-export const InlineSearchForm = ({ onSubmit, className, loading }: Props) => {
+export const InlineSearchForm = ({ onSubmit, className, loading, fieldName }: Props) => {
   const [input, setInput] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
 
@@ -53,6 +54,7 @@ export const InlineSearchForm = ({ onSubmit, className, loading }: Props) => {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           error={!!error}
+          data-testid={`${fieldName}-search-input`}
         />
       </div>
 

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -226,6 +226,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
             >
               <input
                 class="govuk-input lbh-input"
+                data-testid="parentAsset-search-input"
                 style="max-width: 100%;"
                 value=""
               />
@@ -249,7 +250,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
               style="max-width: 100%;"
             >
               <option
-                value=""
+                value="{\\"value\\":\\"\\",\\"label\\":\\"-- Select an option --\\"}"
               >
                 -- Select an option --
               </option>


### PR DESCRIPTION
Production bug: creating a new asset with a parent asset is not possible. The form does not submit.

Error:
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/431af9c0-ccaf-4213-83da-ad3f9775c8dc)

Problem:
![image](https://github.com/LBHackney-IT/mtfh-frontend-property/assets/70756861/0246da5c-f1e9-47d9-8771-a0ff3a4629df)


Following PR (#103) the above issue was introduced. Maybe not enough testing was done after merging as this was just a "refactoring PR".

Currently (in production) when a user selects a parent asset, in the New Asset form, what is actually selected "behind the scenes" is only parent asset ID. This was ok back when all we needed was just the `parentAssetId`, but now we also need to select the whole asset as it to finally populate the `asset.assetLocation.parentAssets` field.

Work done:
- reverted one of the changes of PR #103 (main fix)
- added test IDs to be referenced in E2E test repo (I have incorporated the selection of the parent asset in 2 E2E tests)