### PR TITLE
Get area from asset api

### DIFF
--- a/src/components/patch-details/patch-details.test.tsx
+++ b/src/components/patch-details/patch-details.test.tsx
@@ -53,7 +53,7 @@ const mockAssetArea: Patch = {
 
 const assetWithPatches: Asset = {
   ...mockAssetV1,
-  patches: [mockAssetPatch],
+  patches: [mockAssetPatch, mockAssetArea],
 };
 
 beforeEach(() => {
@@ -64,8 +64,8 @@ beforeEach(() => {
 
 beforeEach(() => {
   server.use(
-    rest.get(`/api/v1/patch/${mockAssetPatch.parentId}`, (req, res, ctx) =>
-      res(ctx.status(200), ctx.json(mockAssetArea)),
+    rest.get(`/api/v1/assets/:id`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(assetWithPatches)),
     ),
   );
 });

--- a/src/components/patch-details/patch-details.test.tsx
+++ b/src/components/patch-details/patch-details.test.tsx
@@ -65,7 +65,7 @@ beforeEach(() => {
 beforeEach(() => {
   server.use(
     rest.get(`/api/v1/assets/:id`, (req, res, ctx) =>
-    res(ctx.status(200), ctx.json(assetWithPatches)),
+      res(ctx.status(200), ctx.json(assetWithPatches)),
     ),
   );
 });

--- a/src/components/patch-details/patch-details.tsx
+++ b/src/components/patch-details/patch-details.tsx
@@ -22,11 +22,10 @@ const PatchTable = ({ patches }: { patches: Patch[] }) => {
   // const parentArea = parentAreaReq.data;
   if (!assetPatch) return <h1>Error: Not found</h1>;
   const housingOfficerName = assetPatch?.responsibleEntities[0]?.name;
-  
+
   const assetArea = patches.find((patch) => patch.patchType === "area");
   if (!assetArea) return <h1>Error: Not found</h1>;
   const housingAreaManagerName = assetArea?.responsibleEntities[0]?.name;
-
 
   const { patchLabel, housingOfficerLabel, areaManagerLabel } = locale.patchDetails;
   return (

--- a/src/components/patch-details/patch-details.tsx
+++ b/src/components/patch-details/patch-details.tsx
@@ -17,9 +17,6 @@ import {
 
 const PatchTable = ({ patches }: { patches: Patch[] }) => {
   const assetPatch = patches.find((patch) => patch.patchType === "patch");
-  // const parentId = assetPatch?.parentId || "";
-  // const parentAreaReq = usePatchOrArea(parentId);
-  // const parentArea = parentAreaReq.data;
   if (!assetPatch) return <h1>Error: Not found</h1>;
   const housingOfficerName = assetPatch?.responsibleEntities[0]?.name;
 

--- a/src/components/patch-details/patch-details.tsx
+++ b/src/components/patch-details/patch-details.tsx
@@ -6,7 +6,7 @@ import Cookies from "js-cookie";
 import { locale } from "../../services";
 
 import { Asset } from "@mtfh/common/lib/api/asset/v1";
-import { Patch, usePatchOrArea } from "@mtfh/common/lib/api/patch/v1";
+import { Patch } from "@mtfh/common/lib/api/patch/v1";
 import {
   Button,
   Heading,
@@ -17,12 +17,16 @@ import {
 
 const PatchTable = ({ patches }: { patches: Patch[] }) => {
   const assetPatch = patches.find((patch) => patch.patchType === "patch");
-  const parentId = assetPatch?.parentId || "";
-  const parentAreaReq = usePatchOrArea(parentId);
-  const parentArea = parentAreaReq.data;
+  // const parentId = assetPatch?.parentId || "";
+  // const parentAreaReq = usePatchOrArea(parentId);
+  // const parentArea = parentAreaReq.data;
   if (!assetPatch) return <h1>Error: Not found</h1>;
-
   const housingOfficerName = assetPatch?.responsibleEntities[0]?.name;
+  
+  const assetArea = patches.find((patch) => patch.patchType === "area");
+  if (!assetArea) return <h1>Error: Not found</h1>;
+  const housingAreaManagerName = assetArea?.responsibleEntities[0]?.name;
+
 
   const { patchLabel, housingOfficerLabel, areaManagerLabel } = locale.patchDetails;
   return (
@@ -42,7 +46,7 @@ const PatchTable = ({ patches }: { patches: Patch[] }) => {
         data-testid="area-manager-name"
         key="areaManagerName"
       >
-        {parentArea?.responsibleEntities[0]?.name}
+        {housingAreaManagerName}
       </SummaryListItem>
     </SummaryList>
   );


### PR DESCRIPTION
Previously we would get the area details from the patches API however we can get this information from the property API itself which would reduce the number of APIs being called. 