### PR TITLE
Let patch details handle heading and nopatch

### DIFF
--- a/src/components/asset-sidebar/__snapshots__/index.test.tsx.snap
+++ b/src/components/asset-sidebar/__snapshots__/index.test.tsx.snap
@@ -103,14 +103,28 @@ exports[`it hides boiler house details 1`] = `
             class="lbh-horizontal-bar"
           />
         </aside>
-        <h2
-          class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+        <aside
+          class="mtfh-patch-details"
         >
-          Patch details
-        </h2>
-        <p>
-          No patch
-        </p>
+          <h2
+            class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+          >
+            Patch details
+          </h2>
+          <p>
+            No patch
+          </p>
+          <a
+            class="govuk-button lbh-button"
+            data-testid="all-patches-and-areas-button"
+            href="/property/all-patches-and-areas"
+          >
+            All patches and areas
+          </a>
+        </aside>
+        <hr
+          class="lbh-horizontal-bar"
+        />
         <aside
           class="mtfh-lbh-ownership-info"
         >
@@ -229,14 +243,28 @@ exports[`it hides cautionary alerts 1`] = `
         <hr
           class="lbh-horizontal-bar"
         />
-        <h2
-          class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+        <aside
+          class="mtfh-patch-details"
         >
-          Patch details
-        </h2>
-        <p>
-          No patch
-        </p>
+          <h2
+            class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+          >
+            Patch details
+          </h2>
+          <p>
+            No patch
+          </p>
+          <a
+            class="govuk-button lbh-button"
+            data-testid="all-patches-and-areas-button"
+            href="/property/all-patches-and-areas"
+          >
+            All patches and areas
+          </a>
+        </aside>
+        <hr
+          class="lbh-horizontal-bar"
+        />
         <aside
           class="mtfh-lbh-ownership-info"
         >
@@ -355,14 +383,28 @@ exports[`it hides tenure information 1`] = `
         <hr
           class="lbh-horizontal-bar"
         />
-        <h2
-          class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+        <aside
+          class="mtfh-patch-details"
         >
-          Patch details
-        </h2>
-        <p>
-          No patch
-        </p>
+          <h2
+            class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+          >
+            Patch details
+          </h2>
+          <p>
+            No patch
+          </p>
+          <a
+            class="govuk-button lbh-button"
+            data-testid="all-patches-and-areas-button"
+            href="/property/all-patches-and-areas"
+          >
+            All patches and areas
+          </a>
+        </aside>
+        <hr
+          class="lbh-horizontal-bar"
+        />
         <aside
           class="mtfh-lbh-ownership-info"
         >
@@ -498,14 +540,28 @@ exports[`it shows boiler house details 1`] = `
             class="lbh-horizontal-bar"
           />
         </aside>
-        <h2
-          class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+        <aside
+          class="mtfh-patch-details"
         >
-          Patch details
-        </h2>
-        <p>
-          No patch
-        </p>
+          <h2
+            class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+          >
+            Patch details
+          </h2>
+          <p>
+            No patch
+          </p>
+          <a
+            class="govuk-button lbh-button"
+            data-testid="all-patches-and-areas-button"
+            href="/property/all-patches-and-areas"
+          >
+            All patches and areas
+          </a>
+        </aside>
+        <hr
+          class="lbh-horizontal-bar"
+        />
         <aside
           class="mtfh-lbh-ownership-info"
         >
@@ -659,14 +715,28 @@ exports[`it shows cautionary alerts 1`] = `
             class="lbh-horizontal-bar"
           />
         </aside>
-        <h2
-          class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+        <aside
+          class="mtfh-patch-details"
         >
-          Patch details
-        </h2>
-        <p>
-          No patch
-        </p>
+          <h2
+            class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+          >
+            Patch details
+          </h2>
+          <p>
+            No patch
+          </p>
+          <a
+            class="govuk-button lbh-button"
+            data-testid="all-patches-and-areas-button"
+            href="/property/all-patches-and-areas"
+          >
+            All patches and areas
+          </a>
+        </aside>
+        <hr
+          class="lbh-horizontal-bar"
+        />
         <aside
           class="mtfh-lbh-ownership-info"
         >
@@ -785,14 +855,28 @@ exports[`it shows tenure information 1`] = `
         <hr
           class="lbh-horizontal-bar"
         />
-        <h2
-          class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+        <aside
+          class="mtfh-patch-details"
         >
-          Patch details
-        </h2>
-        <p>
-          No patch
-        </p>
+          <h2
+            class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+          >
+            Patch details
+          </h2>
+          <p>
+            No patch
+          </p>
+          <a
+            class="govuk-button lbh-button"
+            data-testid="all-patches-and-areas-button"
+            href="/property/all-patches-and-areas"
+          >
+            All patches and areas
+          </a>
+        </aside>
+        <hr
+          class="lbh-horizontal-bar"
+        />
         <aside
           class="mtfh-lbh-ownership-info"
         >

--- a/src/components/asset-sidebar/index.tsx
+++ b/src/components/asset-sidebar/index.tsx
@@ -12,7 +12,7 @@ import { PatchDetails } from "../patch-details/patch-details";
 import { Asset } from "@mtfh/common/lib/api/asset/v1";
 import { Alert } from "@mtfh/common/lib/api/cautionary-alerts/v1/types";
 import { isAuthorisedForGroups } from "@mtfh/common/lib/auth";
-import { Button, Heading, SideBar, SideBarProps } from "@mtfh/common/lib/components";
+import { Button, SideBar, SideBarProps } from "@mtfh/common/lib/components";
 import { isFutureDate } from "@mtfh/common/lib/utils";
 
 interface Props extends Partial<SideBarProps> {
@@ -73,14 +73,10 @@ export const AssetSideBar = ({
           <hr className="lbh-horizontal-bar" />
 
           {showCautionaryAlerts && <CautionaryAlertsDetails alerts={alerts} />}
-          <Heading variant="h2" className="lbh-heading lbh-heading-h3">
-            {locale.patchDetails.heading}
-          </Heading>
-          {patches ? (
-            <PatchDetails assetPk={id} assetPatch={patches[0]} />
-          ) : (
-            <p>{locale.patchDetails.noPatch}</p>
-          )}
+          <PatchDetails
+            assetPk={id}
+            assetPatch={patches?.find((patch) => patch.patchType === "patch")}
+          />
           <LbhOwnershipInformation asset={assetDetails} />
           {showBoilerHouseInformation() && <BoilerHouseDetails asset={assetDetails} />}
           {showTenureInformation && (

--- a/src/views/asset-view/__snapshots__/layout.test.tsx.snap
+++ b/src/views/asset-view/__snapshots__/layout.test.tsx.snap
@@ -109,14 +109,28 @@ exports[`it hides the cautionary alerts icon 1`] = `
               <hr
                 class="lbh-horizontal-bar"
               />
-              <h2
-                class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+              <aside
+                class="mtfh-patch-details"
               >
-                Patch details
-              </h2>
-              <p>
-                No patch
-              </p>
+                <h2
+                  class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+                >
+                  Patch details
+                </h2>
+                <p>
+                  No patch
+                </p>
+                <a
+                  class="govuk-button lbh-button"
+                  data-testid="all-patches-and-areas-button"
+                  href="/property/all-patches-and-areas"
+                >
+                  All patches and areas
+                </a>
+              </aside>
+              <hr
+                class="lbh-horizontal-bar"
+              />
               <aside
                 class="mtfh-lbh-ownership-info"
               >
@@ -529,14 +543,28 @@ exports[`it shows the new cautionary alerts icon 1`] = `
                   class="lbh-horizontal-bar"
                 />
               </aside>
-              <h2
-                class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+              <aside
+                class="mtfh-patch-details"
               >
-                Patch details
-              </h2>
-              <p>
-                No patch
-              </p>
+                <h2
+                  class="lbh-heading-h2 lbh-heading lbh-heading-h3"
+                >
+                  Patch details
+                </h2>
+                <p>
+                  No patch
+                </p>
+                <a
+                  class="govuk-button lbh-button"
+                  data-testid="all-patches-and-areas-button"
+                  href="/property/all-patches-and-areas"
+                >
+                  All patches and areas
+                </a>
+              </aside>
+              <hr
+                class="lbh-horizontal-bar"
+              />
               <aside
                 class="mtfh-lbh-ownership-info"
               >


### PR DESCRIPTION
Fixes an issue where the patch details heading was displayed twice - let the PatchDetails component handle the heading and no patches display