### PR TITLE
nullable email address

### DIFF
--- a/src/components/patch-assignment-form/patch-assignment-form.tsx
+++ b/src/components/patch-assignment-form/patch-assignment-form.tsx
@@ -137,7 +137,7 @@ export const PatchAssignmentForm = ({ setShowSuccess, setRequestError }: Props) 
                     <Td>{areaOrPatch.name}</Td>
                     <Td>{areaOrPatch.parentAreaName}</Td>
                     <Td>{officer?.name}</Td>
-                    <Td>{officer?.contactDetails?.emailAddress.toLowerCase()}</Td>
+                    <Td>{officer?.contactDetails?.emailAddress?.toLowerCase()}</Td>
                     {/* TODO: Toggle this when ready to release patch reassignment */}
                     {false && isAuthorisedForGroups(assetAdminAuthGroups) && (
                       <Td>


### PR DESCRIPTION
Some patches can be vacant hence the name and email address should be nullable. 