### PR TITLE
Handle undefined assetManagement field

### DIFF
--- a/src/components/edit-asset-ownership-form/edit-asset-ownership-form.tsx
+++ b/src/components/edit-asset-ownership-form/edit-asset-ownership-form.tsx
@@ -23,7 +23,7 @@ export const EditAssetOwnershipForm = ({
   asset,
 }: EditAssetOwnershipFormProps) => {
   const [isCouncilProperty, setIsCouncilProperty] = useState<boolean>(
-    asset.assetManagement.isCouncilProperty,
+    asset.assetManagement?.isCouncilProperty,
   );
   const [formSubmitted, setFormSubmitted] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
@@ -125,7 +125,7 @@ export const EditAssetOwnershipForm = ({
             data-testid="submit-edit-ownership-button"
             disabled={
               formSubmitted ||
-              isCouncilProperty === asset.assetManagement.isCouncilProperty
+              isCouncilProperty === asset.assetManagement?.isCouncilProperty
             }
           >
             Confirm change

--- a/src/components/lbh-ownership-information/lbh-ownership-information.tsx
+++ b/src/components/lbh-ownership-information/lbh-ownership-information.tsx
@@ -13,6 +13,15 @@ interface LbhOwnershipInformationProps {
 }
 
 export const LbhOwnershipInformation = ({ asset }: LbhOwnershipInformationProps) => {
+  let displayMessage;
+  if (!asset.assetManagement) {
+    displayMessage = "No asset management data found";
+  } else if (asset.assetManagement?.isCouncilProperty) {
+    displayMessage = locale.lbhOwnershipInformation.ownedByLbh;
+  } else {
+    displayMessage = locale.lbhOwnershipInformation.notOwnedByLbh;
+  }
+
   return (
     <aside className="mtfh-lbh-ownership-info">
       <Heading
@@ -23,15 +32,9 @@ export const LbhOwnershipInformation = ({ asset }: LbhOwnershipInformationProps)
         {locale.lbhOwnershipInformation.sideBarHeading}
       </Heading>
 
-      {asset.assetManagement.isCouncilProperty ? (
-        <Text size="sm" data-testid="ownership-info">
-          {locale.lbhOwnershipInformation.ownedByLbh}
-        </Text>
-      ) : (
-        <Text size="sm" data-testid="ownership-info">
-          {locale.lbhOwnershipInformation.notOwnedByLbh}
-        </Text>
-      )}
+      <Text size="sm" data-testid="ownership-info">
+        {displayMessage}
+      </Text>
 
       {isAuthorisedForGroups(assetAdminAuthGroups) && (
         <Button


### PR DESCRIPTION
This ensures that the property page continues to load in the extremely rare case that the assetManagement field is undefined.

This change is being made to resolve a recently reported production issue affecting a small subset of properties