### PR TITLE
Added 'Rent Group' field to the 'New Property' form.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,11 +119,14 @@ jobs:
             - run:
                   name: Run unit lint-and-test
                   command: yarn test
+            - persist_to_workspace:
+                  root: *workspace_root
+                  paths: .
 
     sonar-scan:
         executor: orb-executor
         steps:
-            - checkout
+            - *attach_workspace
             - sonarcloud/scan
 
     build-deploy-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
     aws-cli: circleci/aws-cli@2.0.0
     aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
     snyk: snyk/snyk@1.0.2
-    sonarcloud: sonarsource/sonarcloud@1.0.3
+    sonarcloud: sonarsource/sonarcloud@2.0.0
 
 parameters:
     run_development_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,8 +258,12 @@ workflows:
         jobs:
             - install-dependencies
             - lint-and-test:
-                  context: SonarCloud
                   requires:
+                      - install-dependencies
+            # This scan can run in parallel to the tests.
+            - sonar-scan:
+                context: SonarCloud
+                requires:
                       - install-dependencies
 #             - security-scan:
 #                   context: mtfh-security-scan
@@ -273,6 +277,7 @@ workflows:
                   requires:
                     #   - security-scan
                       - lint-and-test
+                      - sonar-scan
                   filters:
                       branches:
                           only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ executors:
     node-executor:
         docker:
             - image: circleci/node:14.17.0-browsers
+    orb-executor:
+        docker:
+            - image: cimg/node:21.6.1-browsers
     docker-terraform:
         docker:
             - image: "hashicorp/terraform:light"
@@ -116,7 +119,13 @@ jobs:
             - run:
                   name: Run unit lint-and-test
                   command: yarn test
+
+    sonar-scan:
+        executor: orb-executor
+        steps:
+            - checkout
             - sonarcloud/scan
+
     build-deploy-development:
         executor: node-executor
         environment:

--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -22,7 +22,7 @@ import { renderManagingOrganisationOptions } from "./utils/managing-organisation
 import { reducer } from "./utils/reducer";
 
 import { Center, Spinner } from "@mtfh/common";
-import { createAsset } from "@mtfh/common/lib/api/asset/v1";
+import { RentGroup, createAsset } from "@mtfh/common/lib/api/asset/v1";
 import { CreateNewAssetRequest } from "@mtfh/common/lib/api/asset/v1/types";
 import { Patch, getAllPatchesAndAreas } from "@mtfh/common/lib/api/patch/v1";
 
@@ -132,6 +132,7 @@ export const NewAsset = ({
           areaId: "",
           patchId: "",
           assetType: "",
+          rentGroup: undefined,
           parentAsset: "",
           floorNo: "",
           totalBlockFloors: undefined,
@@ -246,6 +247,7 @@ export const NewAsset = ({
                   ))}
                 </Field>
               </div>
+
               <InlineAssetSearch
                 assetTypes={[]}
                 name="parentAsset"
@@ -307,6 +309,54 @@ export const NewAsset = ({
                   </div>
                 </>
               )}
+
+              <div
+                className={
+                  errors.rentGroup && touched.rentGroup
+                    ? "govuk-form-group govuk-form-group--error lbh-form-group"
+                    : "govuk-form-group lbh-form-group"
+                }
+              >
+                <label className="govuk-label lbh-label" htmlFor="rentGroup">
+                  Rent Group
+                </label>
+                {errors.rentGroup && touched.rentGroup && (
+                  <span
+                    id="rentGroup-input-error"
+                    className="govuk-error-message lbh-error-message"
+                  >
+                    <span
+                      className="govuk-visually-hidden"
+                      data-testid="error-rent-group"
+                    >
+                      Error:
+                    </span>
+                    {errors.rentGroup}
+                  </span>
+                )}
+                <Field
+                  as="select"
+                  id="rent-group"
+                  name="rentGroup"
+                  className={
+                    errors.rentGroup && touched.rentGroup
+                      ? "govuk-input lbh-input govuk-input--error"
+                      : "govuk-input lbh-input"
+                  }
+                  data-testid="rent-group"
+                >
+                  <option selected value="">
+                    {" "}
+                    -- Select an option --{" "}
+                  </option>
+                  {Object.keys(RentGroup).map((key) => (
+                    <option key={key} value={key}>
+                      {key}
+                    </option>
+                  ))}
+                </Field>
+              </div>
+
               <h2 className="lbh-heading-h2">Address</h2>
               <label className="govuk-label lbh-label" htmlFor="uprn">
                 UPRN

--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -2,6 +2,7 @@ import * as Yup from "yup";
 
 import { regexUkPostcode } from "../../utils/uk-postcode-regex";
 
+import { RentGroup } from "@mtfh/common/lib/api/asset/v1";
 import { removeWhitespace } from "@mtfh/common/lib/utils";
 
 export const newPropertySchema = () =>
@@ -10,6 +11,9 @@ export const newPropertySchema = () =>
     areaId: Yup.string(),
     patchId: Yup.string(),
     assetType: Yup.string().required("Asset Type is a required field"),
+    rentGroup: Yup.string()
+      .nullable()
+      .oneOf([undefined, null, ...Object.keys(RentGroup)]),
     parentAsset: Yup.string(),
     floorNo: Yup.string(),
     totalBlockFloors: Yup.number()

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -3,7 +3,11 @@ import { v4 as uuidv4 } from "uuid";
 import { NewPropertyFormData } from "../components/new-asset-form/schema";
 import { managingOrganisations } from "../components/new-asset-form/utils/managing-organisations";
 
-import { CreateNewAssetRequest, ParentAsset } from "@mtfh/common/lib/api/asset/v1";
+import {
+  CreateNewAssetRequest,
+  ParentAsset,
+  RentGroup,
+} from "@mtfh/common/lib/api/asset/v1";
 import { Patch } from "@mtfh/common/lib/api/patch/v1";
 
 export const assembleCreateNewAssetRequest = (
@@ -19,6 +23,7 @@ export const assembleCreateNewAssetRequest = (
     areaId,
     patchId,
     assetType: values.assetType,
+    rentGroup: RentGroup[values.rentGroup as keyof typeof RentGroup],
     parentAssetIds: values?.parentAsset ? getParentAsset(values?.parentAsset).id : "",
     isActive: true,
     assetLocation: {

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -257,6 +257,73 @@ exports[`renders the whole 'New asset form' view 1`] = `
             </select>
           </div>
         </div>
+        <div
+          class="govuk-form-group lbh-form-group"
+        >
+          <label
+            class="govuk-label lbh-label"
+            for="rentGroup"
+          >
+            Rent Group
+          </label>
+          <select
+            class="govuk-input lbh-input"
+            data-testid="rent-group"
+            id="rent-group"
+            name="rentGroup"
+          >
+            <option
+              value=""
+            >
+               -- Select an option -- 
+            </option>
+            <option
+              value="GPS"
+            >
+              GPS
+            </option>
+            <option
+              value="HGF"
+            >
+              HGF
+            </option>
+            <option
+              value="HRA"
+            >
+              HRA
+            </option>
+            <option
+              value="LMW"
+            >
+              LMW
+            </option>
+            <option
+              value="LSC"
+            >
+              LSC
+            </option>
+            <option
+              value="RSL"
+            >
+              RSL
+            </option>
+            <option
+              value="TAG"
+            >
+              TAG
+            </option>
+            <option
+              value="TAH"
+            >
+              TAH
+            </option>
+            <option
+              value="TRA"
+            >
+              TRA
+            </option>
+          </select>
+        </div>
         <h2
           class="lbh-heading-h2"
         >

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,7 +1555,8 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#e796c4a55d233678fb82136cee4f29489e28e154"
+  uid "75c2f52fb23a091fc436cdc68f85a15ef8d5d97f"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#75c2f52fb23a091fc436cdc68f85a15ef8d5d97f"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"
@@ -1588,7 +1589,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#eddd7fbc12504ad7916a831bce65b7794378ea1b"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#75c2f52fb23a091fc436cdc68f85a15ef8d5d97f"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"


### PR DESCRIPTION
# What:
 - Added a field to the form to capture the rent group information whilst creating an Asset via 'New Property' form.
 - Upgrade CircleCI 'sonarsource/sonarcloud' orb version from v1.0.3 to v2.0.0.
 - Added separate CCI executor for the Sonar Scan & separated the scan into a separate job.

# Why:
## Rent Group field
We have the MMH system for managing Assets and Tenancies separate from the HFS system managing the finance side of this. It so happens that the HFS system needs part of the data that is now being managed by the MMH. It's not practical for HFS system to access MMH system data for the financial and reporting operations that it needs. As such a sync of that kind of data is needed. Currently it is done by a semi-automatic process that involves copying whatever was inputted into MMH into GDrive spreadsheet that gets picked by Nightly process.

Due to the semi-automatic process being labour intensive, error prone, and slow to reflect the actual state of the data available, a full automation of the sync process was proposed. For us to do-away with the current spreadsheet solution & the sync to be MMH side driven, a 'Rent Group' information needs to be recorded within the MMH _(as right now it's being manually maintained within the Google sheet by the system users)_. This field is vital for determining the charges on the Tenure or Property.

The adding of this field ensures that any new Assets coming into MMH can have their Rent Group set upon their creation.

## Sonar Cloud orb
Upgraded the orb because the pipeline has ran into deprecation error for v11 of Java, which is used by the v1.0.3 version of the orb. According to the Sonar Source [announcement](https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597?page=2), upgrading to the orb to v2.0.0 should fix the issue.

## Sonar Scan job
Created separate CCI executor to satisfy sonarcloud v2.0.0 orb's Node v16.0+ requirement. Has to be a separate executor not to conflict with a lower version codebase.

# Notes:
 - This PR is linked to the **mtfh-frontend-common** [PR #290](https://github.com/LBHackney-IT/mtfh-frontend-common/pull/290).
 - The work for syncing between the MMH and HFS systems has been paused in favour of delivering a better charges recording, auditing, and management solution _(which also got paused due to yet another change of focus - this time to Repairs)_. Regardless of that, before this piece of work was paused, a data migration task has been completed to populate the MMH with the 'Rent Groups' data. It may take some time to get back to the sync work, during which time the new incoming Asset records will have no 'Rent Groups'. For us to avoid needing another investigation into missing Rent Groups and another data import, we're adding in a field to capture the Rent Groups on the new incoming Assets for the meanwhile whilst the sync work is paused.
 - Future work: Rent Groups can change over time _(like be removed from an Asset if it's sold or demolished)_. As such, another form may be needed _(or needed to be extended)_ to allow for such management of Rent Groups.

# Screenshot:
| <img src="https://github.com/LBHackney-IT/mtfh-frontend-property/assets/43747286/af4e9cc0-75dd-4df8-809a-2fcefb6f8a05" width="200" /> |
| --- |
| A screenshot of the Rent Group drop-down box within the form. |