### PR TITLE
Add better 'RentGroup' code descriptions to the New Property form.

### DIFF
--- a/src/components/new-asset-form/new-asset.tsx
+++ b/src/components/new-asset-form/new-asset.tsx
@@ -349,9 +349,9 @@ export const NewAsset = ({
                     {" "}
                     -- Select an option --{" "}
                   </option>
-                  {Object.keys(RentGroup).map((key) => (
+                  {Object.entries(RentGroup).map(([key, desc]) => (
                     <option key={key} value={key}>
-                      {key}
+                      {`${key} - ${desc}`}
                     </option>
                   ))}
                 </Field>

--- a/src/components/new-asset-form/schema.ts
+++ b/src/components/new-asset-form/schema.ts
@@ -11,9 +11,7 @@ export const newPropertySchema = () =>
     areaId: Yup.string(),
     patchId: Yup.string(),
     assetType: Yup.string().required("Asset Type is a required field"),
-    rentGroup: Yup.string()
-      .nullable()
-      .oneOf([undefined, null, ...Object.keys(RentGroup)]),
+    rentGroup: Yup.string().oneOf([undefined, "", ...Object.keys(RentGroup)]),
     parentAsset: Yup.string(),
     floorNo: Yup.string(),
     totalBlockFloors: Yup.number()

--- a/src/factories/requestFactory.ts
+++ b/src/factories/requestFactory.ts
@@ -23,7 +23,7 @@ export const assembleCreateNewAssetRequest = (
     areaId,
     patchId,
     assetType: values.assetType,
-    rentGroup: RentGroup[values.rentGroup as keyof typeof RentGroup],
+    rentGroup: getRentGroupEitherAsKeyOrNothing(values.rentGroup),
     parentAssetIds: values?.parentAsset ? getParentAsset(values?.parentAsset).id : "",
     isActive: true,
     assetLocation: {
@@ -98,3 +98,10 @@ const getParentId = (patch: Patch): string => {
 const getPatchId = (patch: Patch): string => {
   return patch.id;
 };
+
+const getRentGroupEitherAsKeyOrNothing = (
+  rentGroupKey: string | undefined,
+): RentGroup | undefined =>
+  RentGroup[rentGroupKey as keyof typeof RentGroup]
+    ? (rentGroupKey as RentGroup)
+    : undefined;

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -310,7 +310,7 @@ exports[`renders the whole 'New asset form' view 1`] = `
             <option
               value="TAG"
             >
-              TAG - Temporary Accommodation General Fun
+              TAG - Temporary Accommodation General Fund
             </option>
             <option
               value="TAH"

--- a/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
+++ b/src/views/new-asset-view/__snapshots__/new-asset-view.test.tsx.snap
@@ -280,47 +280,47 @@ exports[`renders the whole 'New asset form' view 1`] = `
             <option
               value="GPS"
             >
-              GPS
+              GPS - Garages & Parking Spaces HRA
             </option>
             <option
               value="HGF"
             >
-              HGF
+              HGF - Housing General Fund
             </option>
             <option
               value="HRA"
             >
-              HRA
+              HRA - Housing Revenue Account
             </option>
             <option
               value="LMW"
             >
-              LMW
+              LMW - Leasehold Major Works
             </option>
             <option
               value="LSC"
             >
-              LSC
+              LSC - Leasehold Service Charges
             </option>
             <option
               value="RSL"
             >
-              RSL
+              RSL - Registered Social Landlord and XBorough
             </option>
             <option
               value="TAG"
             >
-              TAG
+              TAG - Temporary Accommodation General Fun
             </option>
             <option
               value="TAH"
             >
-              TAH
+              TAH - Temporary Accommodation HRA
             </option>
             <option
               value="TRA"
             >
-              TRA
+              TRA - Travellers General Fund
             </option>
           </select>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,8 +1555,8 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common":
   version "0.0.1"
-  uid "636573ff7e8bc8999dc4bf857cb40e8b47e53dbc"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#636573ff7e8bc8999dc4bf857cb40e8b47e53dbc"
+  uid bd2570c284acf33796b421cc76ed96d6dd58a6c5
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#bd2570c284acf33796b421cc76ed96d6dd58a6c5"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"
@@ -1589,7 +1589,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#636573ff7e8bc8999dc4bf857cb40e8b47e53dbc"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#bd2570c284acf33796b421cc76ed96d6dd58a6c5"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,8 +1555,8 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common":
   version "0.0.1"
-  uid "75c2f52fb23a091fc436cdc68f85a15ef8d5d97f"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#75c2f52fb23a091fc436cdc68f85a15ef8d5d97f"
+  uid "636573ff7e8bc8999dc4bf857cb40e8b47e53dbc"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common#636573ff7e8bc8999dc4bf857cb40e8b47e53dbc"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"
@@ -1589,7 +1589,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#75c2f52fb23a091fc436cdc68f85a15ef8d5d97f"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#636573ff7e8bc8999dc4bf857cb40e8b47e53dbc"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"


### PR DESCRIPTION
# What:
 - Made the 'Rent Group' select options show Rent Group code descriptions in addition to the codes themselves.

# Why:
 - There are a couple of user groups that _are/may_ be using the form. Not all of them are familiar with the Rent Group codes as not all of them have been involved in finance as much others.

# Notes:
 - Updated the schema as the 'rentGroup' cannot become nullable - it's either a string, or undefined.
 - Also had to make some changes within the request mapper for to take into account the 'RentGroup' values are no longer codes.
 - This PR extends the PR #128 .
 - Uses `mtfh-fronted-common` version: PR [#292](https://github.com/LBHackney-IT/mtfh-frontend-common/pull/292), which is an extension of PR [#291](https://github.com/LBHackney-IT/mtfh-frontend-common/pull/291).

# Screenshots:
| <img src="https://github.com/LBHackney-IT/mtfh-frontend-property/assets/43747286/98ca0410-cca8-40ec-8fb6-a92534b29498" width="300" /> |
| --- |
| A screenshot of the Rent Group drop-down box within the form. |
