### PR TITLE
Fix error if patch or area responsible entities are empty

### DIFF
--- a/src/components/patch-details/patch-details.test.tsx
+++ b/src/components/patch-details/patch-details.test.tsx
@@ -33,6 +33,15 @@ const mockAssetPatch: Patch = {
   ],
 };
 
+const mockAssetPatchWithoutResponsibleEntities: Patch = {
+  id: crypto.randomBytes(20).toString("hex"),
+  name: "AR1",
+  patchType: "patch",
+  parentId: mockAreaId,
+  domain: "Hackney",
+  responsibleEntities: []
+}
+
 const mockAssetArea: Patch = {
   id: mockAreaId,
   name: "AR",
@@ -50,6 +59,15 @@ const mockAssetArea: Patch = {
     },
   ],
 };
+
+const mockAssetAreaWithoutResponsibleEntities: Patch = {
+  id: mockAreaId,
+  name: "AR",
+  patchType: "area",
+  parentId: crypto.randomBytes(20).toString("hex"),
+  domain: "Hackney",
+  responsibleEntities: []
+}
 
 const assetWithPatches: Asset = {
   ...mockAssetV1,
@@ -140,6 +158,52 @@ describe("Patch Details", () => {
     expect(officerNameField).toHaveTextContent(
       mockAssetPatch.responsibleEntities[0].name,
     );
+    expect(areaManagerNameField).toHaveTextContent(
+      mockAssetArea.responsibleEntities[0].name,
+    );
+  });
+
+  test("it displays the patch and housing officer when area manager is not defined", async () => {
+    render(
+      <PatchDetails
+        assetPk={assetWithPatches.id}
+        assetPatch={mockAssetPatch}
+        assetArea={mockAssetAreaWithoutResponsibleEntities}
+      />,
+    );
+    await waitFor(async () => {
+      screen.getByTestId("patch-name");
+    });
+
+    const patchNameField = screen.getByTestId("patch-name");
+    const officerNameField = screen.getByTestId("officer-name");
+    const areaManagerNameField = screen.getByTestId("area-manager-name");
+
+    expect(patchNameField).toHaveTextContent(mockAssetPatch.name);
+    expect(officerNameField).toHaveTextContent(
+      mockAssetPatch.responsibleEntities[0].name,
+    );
+    expect(areaManagerNameField).toHaveTextContent("N/A");
+  });
+
+  test("it displays the patch and area manager when housing officer is not defined", async () => {
+    render(
+      <PatchDetails
+        assetPk={assetWithPatches.id}
+        assetPatch={mockAssetPatchWithoutResponsibleEntities}
+        assetArea={mockAssetArea}
+      />,
+    );
+    await waitFor(async () => {
+      screen.getByTestId("patch-name");
+    });
+
+    const patchNameField = screen.getByTestId("patch-name");
+    const officerNameField = screen.getByTestId("officer-name");
+    const areaManagerNameField = screen.getByTestId("area-manager-name");
+
+    expect(patchNameField).toHaveTextContent(mockAssetPatch.name);
+    expect(officerNameField).toHaveTextContent("N/A");
     expect(areaManagerNameField).toHaveTextContent(
       mockAssetArea.responsibleEntities[0].name,
     );

--- a/src/components/patch-details/patch-details.test.tsx
+++ b/src/components/patch-details/patch-details.test.tsx
@@ -39,8 +39,8 @@ const mockAssetPatchWithoutResponsibleEntities: Patch = {
   patchType: "patch",
   parentId: mockAreaId,
   domain: "Hackney",
-  responsibleEntities: []
-}
+  responsibleEntities: [],
+};
 
 const mockAssetArea: Patch = {
   id: mockAreaId,
@@ -66,8 +66,8 @@ const mockAssetAreaWithoutResponsibleEntities: Patch = {
   patchType: "area",
   parentId: crypto.randomBytes(20).toString("hex"),
   domain: "Hackney",
-  responsibleEntities: []
-}
+  responsibleEntities: [],
+};
 
 const assetWithPatches: Asset = {
   ...mockAssetV1,

--- a/src/components/patch-details/patch-details.tsx
+++ b/src/components/patch-details/patch-details.tsx
@@ -25,8 +25,8 @@ export const PatchDetails = ({ assetPk, assetPatch, assetArea }: PatchDetailsPro
   const { patchLabel, housingOfficerLabel, areaManagerLabel } = locale.patchDetails;
 
   const patchOrAreaDefined = assetPatch || assetArea;
-  const housingOfficerName = assetPatch?.responsibleEntities[0].name;
-  const areaManagerName = assetArea?.responsibleEntities[0].name;
+  const housingOfficerName = assetPatch?.responsibleEntities[0]?.name;
+  const areaManagerName = assetArea?.responsibleEntities[0]?.name;
 
   return (
     <>
@@ -45,14 +45,14 @@ export const PatchDetails = ({ assetPk, assetPatch, assetArea }: PatchDetailsPro
               data-testid="officer-name"
               key="officerName"
             >
-              {housingOfficerName}
+              {housingOfficerName || "N/A"}
             </SummaryListItem>
             <SummaryListItem
               title={areaManagerLabel}
               data-testid="area-manager-name"
               key="areaManagerName"
             >
-              {areaManagerName}
+              {areaManagerName || "N/A"}
             </SummaryListItem>
           </SummaryList>
         ) : (


### PR DESCRIPTION
Update `PatchDetails` component to handle cases where responsible entities is empty (e.g. here - https://manage-my-home-development.hackney.gov.uk/property/5aca3cdd-5e00-b0f5-ca19-cb219a832199)