### PR TITLE
Remove patch UI from property view and update tenancy services message.

### DIFF
--- a/src/components/asset-sidebar/__snapshots__/index.test.tsx.snap
+++ b/src/components/asset-sidebar/__snapshots__/index.test.tsx.snap
@@ -111,29 +111,11 @@ exports[`Assets Sidebar it hides boiler house details 1`] = `
           >
             Patch details
           </h2>
-          <p>
-            No patch
-          </p>
-          <aside
-            class="mtfh-edit-patch-details"
-          >
-            <button
-              class="govuk-button lbh-button"
-              data-testid="edit-assignment-button"
-              style="margin-top: 0px;"
-              type="button"
-            >
-              Edit
-            </button>
-          </aside>
-          <hr
-            class="lbh-horizontal-bar"
-          />
           <p
             class="lbh-body-s"
             data-testid="patch-note"
           >
-            From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.
+            The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.
           </p>
         </aside>
         <hr
@@ -265,29 +247,11 @@ exports[`Assets Sidebar it hides cautionary alerts 1`] = `
           >
             Patch details
           </h2>
-          <p>
-            No patch
-          </p>
-          <aside
-            class="mtfh-edit-patch-details"
-          >
-            <button
-              class="govuk-button lbh-button"
-              data-testid="edit-assignment-button"
-              style="margin-top: 0px;"
-              type="button"
-            >
-              Edit
-            </button>
-          </aside>
-          <hr
-            class="lbh-horizontal-bar"
-          />
           <p
             class="lbh-body-s"
             data-testid="patch-note"
           >
-            From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.
+            The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.
           </p>
         </aside>
         <hr
@@ -419,29 +383,11 @@ exports[`Assets Sidebar it hides tenure information 1`] = `
           >
             Patch details
           </h2>
-          <p>
-            No patch
-          </p>
-          <aside
-            class="mtfh-edit-patch-details"
-          >
-            <button
-              class="govuk-button lbh-button"
-              data-testid="edit-assignment-button"
-              style="margin-top: 0px;"
-              type="button"
-            >
-              Edit
-            </button>
-          </aside>
-          <hr
-            class="lbh-horizontal-bar"
-          />
           <p
             class="lbh-body-s"
             data-testid="patch-note"
           >
-            From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.
+            The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.
           </p>
         </aside>
         <hr
@@ -590,29 +536,11 @@ exports[`Assets Sidebar it shows boiler house details 1`] = `
           >
             Patch details
           </h2>
-          <p>
-            No patch
-          </p>
-          <aside
-            class="mtfh-edit-patch-details"
-          >
-            <button
-              class="govuk-button lbh-button"
-              data-testid="edit-assignment-button"
-              style="margin-top: 0px;"
-              type="button"
-            >
-              Edit
-            </button>
-          </aside>
-          <hr
-            class="lbh-horizontal-bar"
-          />
           <p
             class="lbh-body-s"
             data-testid="patch-note"
           >
-            From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.
+            The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.
           </p>
         </aside>
         <hr
@@ -779,29 +707,11 @@ exports[`Assets Sidebar it shows cautionary alerts 1`] = `
           >
             Patch details
           </h2>
-          <p>
-            No patch
-          </p>
-          <aside
-            class="mtfh-edit-patch-details"
-          >
-            <button
-              class="govuk-button lbh-button"
-              data-testid="edit-assignment-button"
-              style="margin-top: 0px;"
-              type="button"
-            >
-              Edit
-            </button>
-          </aside>
-          <hr
-            class="lbh-horizontal-bar"
-          />
           <p
             class="lbh-body-s"
             data-testid="patch-note"
           >
-            From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.
+            The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.
           </p>
         </aside>
         <hr
@@ -933,29 +843,11 @@ exports[`Assets Sidebar it shows tenure information 1`] = `
           >
             Patch details
           </h2>
-          <p>
-            No patch
-          </p>
-          <aside
-            class="mtfh-edit-patch-details"
-          >
-            <button
-              class="govuk-button lbh-button"
-              data-testid="edit-assignment-button"
-              style="margin-top: 0px;"
-              type="button"
-            >
-              Edit
-            </button>
-          </aside>
-          <hr
-            class="lbh-horizontal-bar"
-          />
           <p
             class="lbh-body-s"
             data-testid="patch-note"
           >
-            From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.
+            The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.
           </p>
         </aside>
         <hr

--- a/src/components/asset-sidebar/index.tsx
+++ b/src/components/asset-sidebar/index.tsx
@@ -40,16 +40,8 @@ export const AssetSideBar = ({
   showCautionaryAlerts,
   ...properties
 }: Props) => {
-  const {
-    assetAddress,
-    assetId,
-    assetType,
-    tenure,
-    id,
-    assetCharacteristics,
-    patchId,
-    areaId,
-  } = assetDetails;
+  const { assetAddress, assetId, assetType, tenure, id, assetCharacteristics } =
+    assetDetails;
 
   // only show button when there is no active tenure on the asset
   const showAddTenureButton = () =>
@@ -81,12 +73,7 @@ export const AssetSideBar = ({
           <hr className="lbh-horizontal-bar" />
 
           {showCautionaryAlerts && <CautionaryAlertsDetails alerts={alerts} />}
-          <PatchDetails
-            assetPk={id}
-            initialPatchId={patchId}
-            initialAreaId={areaId}
-            versionNumber={assetDetails?.versionNumber}
-          />
+          <PatchDetails />
           <LbhOwnershipInformation asset={assetDetails} />
           {showBoilerHouseInformation() && <BoilerHouseDetails asset={assetDetails} />}
           {showTenureInformation && (

--- a/src/components/patch-details/patch-details.test.tsx
+++ b/src/components/patch-details/patch-details.test.tsx
@@ -1,182 +1,44 @@
-import * as crypto from "crypto";
-
 import React from "react";
 
-import { mockAssetV1, render, server } from "@hackney/mtfh-test-utils";
+import { render } from "@hackney/mtfh-test-utils";
 import { screen, waitFor } from "@testing-library/react";
-import { rest } from "msw";
 
 import { locale } from "../../services";
 import { PatchDetails } from "./patch-details";
 
-import { Asset } from "@mtfh/common/lib/api/asset/v1";
-import { Patch } from "@mtfh/common/lib/api/patch/v1/types";
-import * as auth from "@mtfh/common/lib/auth/auth";
-
-const mockAreaId = crypto.randomBytes(20).toString("hex");
-
-const mockAssetPatch: Patch = {
-  id: crypto.randomBytes(20).toString("hex"),
-  name: "AR1",
-  patchType: "patch",
-  parentId: mockAreaId,
-  domain: "Hackney",
-  responsibleEntities: [
-    {
-      id: crypto.randomBytes(20).toString("hex"),
-      name: "Housing Officer 1",
-      responsibleType: "HousingOfficer",
-      contactDetails: {
-        emailAddress: "test.test@hackney.gov.uk",
-      },
-    },
-  ],
-};
-
-const mockAssetArea: Patch = {
-  id: mockAreaId,
-  name: "AR",
-  patchType: "area",
-  parentId: crypto.randomBytes(20).toString("hex"),
-  domain: "Hackney",
-  responsibleEntities: [
-    {
-      id: crypto.randomBytes(20).toString("hex"),
-      name: "Area Manager 1",
-      responsibleType: "HousingAreaManager",
-      contactDetails: {
-        emailAddress: "test.test@hackney.gov.uk",
-      },
-    },
-  ],
-};
-
-const assetWithPatches: Asset = {
-  ...mockAssetV1,
-  patchId: mockAssetPatch.id,
-  areaId: mockAssetArea.id,
-};
-
-const mockPatch: Patch = {
-  id: crypto.randomBytes(20).toString("hex"),
-  name: "HN1",
-  patchType: "patch",
-  parentId: mockAreaId,
-  domain: "Hackney",
-  responsibleEntities: [
-    {
-      id: crypto.randomBytes(20).toString("hex"),
-      name: "Housing Officer 1",
-      responsibleType: "HousingOfficer",
-      contactDetails: {
-        emailAddress: "test.test@hackney.gov.uk",
-      },
-    },
-  ],
-};
-
-const mockPatchList: Patch[] = [mockPatch, mockAssetPatch];
-
-// Mock the API response for the patch list
-beforeEach(() => {
-  jest.resetAllMocks();
-
-  jest.spyOn(auth, "isAuthorisedForGroups").mockReturnValue(true);
-
-  server.use(
-    rest.get(`/api/v1/patch/${mockAssetPatch.id}`, (req, res, ctx) =>
-      res(ctx.status(200), ctx.json(mockAssetPatch)),
-    ),
-  );
-  server.use(
-    rest.get(`/api/v1/patch/${mockAssetPatch.parentId}`, (req, res, ctx) =>
-      res(ctx.status(200), ctx.json(mockAssetArea)),
-    ),
-  );
-  server.use(
-    rest.get("/api/v1/patch/all", (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json(mockPatchList));
-    }),
-  );
-  server.use(
-    rest.get(`/api/v1/patch/patchName/*`, (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json(mockPatch));
-    }),
-  );
-  server.use(
-    rest.patch(`/api/v1/assets/${assetWithPatches.id}/patch`, (req, res, ctx) =>
-      res(ctx.status(204)),
-    ),
-  );
-});
-
 describe("Patch Details", () => {
   test("it renders the component", async () => {
-    render(
-      <PatchDetails
-        assetPk={assetWithPatches.id}
-        initialPatchId={mockAssetPatch.id}
-        initialAreaId={mockAreaId}
-      />,
-    );
+    render(<PatchDetails />);
 
     await screen.findByText(locale.patchDetails.heading);
   });
 
-  test("it displays the patch name", async () => {
-    render(
-      <PatchDetails
-        assetPk={assetWithPatches.id}
-        initialPatchId={mockAssetPatch.id}
-        initialAreaId={mockAreaId}
-      />,
-    );
-
-    await waitFor(async () => {
-      screen.getByTestId("patch-name");
-    });
-
-    expect(screen.getByTestId("patch-name")).toHaveTextContent(mockAssetPatch.name);
-    expect(screen.queryByTestId("officer-name")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("area-manager-name")).not.toBeInTheDocument();
-  });
-
-  test("it displays a 'no patch' message when asset has no patches", async () => {
-    render(<PatchDetails assetPk={mockAssetV1.id} initialPatchId="" initialAreaId="" />);
-
-    await waitFor(async () => {
-      expect(screen.getByText(locale.patchDetails.noPatch)).toBeVisible();
-    });
-    expect(screen.queryByTestId("patch-name")).not.toBeInTheDocument();
-  });
-
-  test("it does not show the all patches and areas button", async () => {
-    render(
-      <PatchDetails
-        assetPk={assetWithPatches.id}
-        initialPatchId={mockAssetPatch.id}
-        initialAreaId={mockAreaId}
-      />,
-    );
-
-    await screen.findByTestId("patch-name");
-
-    expect(screen.queryByTestId("all-patches-and-areas-button")).not.toBeInTheDocument();
-  });
-
   test("it shows the explanatory note", async () => {
-    render(
-      <PatchDetails
-        assetPk={assetWithPatches.id}
-        initialPatchId={mockAssetPatch.id}
-        initialAreaId={mockAreaId}
-      />,
-    );
+    render(<PatchDetails />);
 
     await waitFor(async () => {
       expect(screen.getByTestId("patch-note")).toHaveTextContent(
         locale.patchDetails.note,
+        { normalizeWhitespace: false },
       );
     });
+  });
+
+  test("it does not show the patch name", () => {
+    render(<PatchDetails />);
+
+    expect(screen.queryByTestId("patch-name")).not.toBeInTheDocument();
+  });
+
+  test("it does not show the edit patch button", () => {
+    render(<PatchDetails />);
+
+    expect(screen.queryByTestId("edit-assignment-button")).not.toBeInTheDocument();
+  });
+
+  test("it does not show the all patches and areas button", () => {
+    render(<PatchDetails />);
+
+    expect(screen.queryByTestId("all-patches-and-areas-button")).not.toBeInTheDocument();
   });
 });

--- a/src/components/patch-details/patch-details.tsx
+++ b/src/components/patch-details/patch-details.tsx
@@ -1,44 +1,11 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { locale } from "../../services";
-import { patchAdminAuthGroups } from "../../services/config/config";
-import { PatchEdit } from "./patch-edit";
 
-import { usePatchOrArea } from "@mtfh/common/lib/api/patch/v1";
-import { isAuthorisedForGroups } from "@mtfh/common/lib/auth";
-import { Heading, SummaryList, SummaryListItem } from "@mtfh/common/lib/components";
+import { Heading } from "@mtfh/common/lib/components";
 
-interface PatchDetailsProps {
-  assetPk: string;
-  initialPatchId: string;
-  initialAreaId: string;
-  versionNumber?: number;
-}
-
-export const PatchDetails = ({
-  assetPk,
-  initialPatchId,
-  initialAreaId,
-  versionNumber,
-}: PatchDetailsProps) => {
-  const [patchId, setPatchId] = useState(initialPatchId);
-  const [areaId, setAreaId] = useState(initialAreaId);
-
-  const { data: assetPatch, mutate: mutatePatch } = usePatchOrArea(patchId);
-  const { data: assetArea, mutate: mutateArea } = usePatchOrArea(areaId);
-
+export const PatchDetails = () => {
   const { heading } = locale.patchDetails;
-
-  const { patchLabel } = locale.patchDetails;
-
-  const patchOrAreaDefined = assetPatch || assetArea;
-
-  const onEdit = (patchId: string, areaId: string) => {
-    setPatchId(patchId);
-    setAreaId(areaId);
-    mutatePatch();
-    mutateArea();
-  };
 
   return (
     <>
@@ -46,23 +13,6 @@ export const PatchDetails = ({
         <Heading variant="h2" className="lbh-heading lbh-heading-h3">
           {heading}
         </Heading>
-        {patchOrAreaDefined ? (
-          <SummaryList overrides={[2 / 3]}>
-            <SummaryListItem title={patchLabel} data-testid="patch-name" key="patchName">
-              {assetPatch?.name}
-            </SummaryListItem>
-          </SummaryList>
-        ) : (
-          <p>{locale.patchDetails.noPatch}</p>
-        )}
-        {isAuthorisedForGroups(patchAdminAuthGroups) && (
-          <PatchEdit
-            assetPk={assetPk}
-            patchName={assetPatch?.name || ""}
-            versionNumber={versionNumber}
-            onEdit={onEdit}
-          />
-        )}
         <p className="lbh-body-s" data-testid="patch-note">
           {locale.patchDetails.note}
         </p>

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -102,7 +102,7 @@ export default {
     areaManagerLabel: "Area manager",
     allPatchesAndAreas: "All patches and areas",
     noPatch: "No patch",
-    note: "From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.",
+    note: "The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.",
   },
   boilerHouseDetails: {
     heading: "Boiler house",

--- a/src/views/asset-view/__snapshots__/layout.test.tsx.snap
+++ b/src/views/asset-view/__snapshots__/layout.test.tsx.snap
@@ -117,29 +117,11 @@ exports[`it hides the cautionary alerts icon 1`] = `
                 >
                   Patch details
                 </h2>
-                <p>
-                  No patch
-                </p>
-                <aside
-                  class="mtfh-edit-patch-details"
-                >
-                  <button
-                    class="govuk-button lbh-button"
-                    data-testid="edit-assignment-button"
-                    style="margin-top: 0px;"
-                    type="button"
-                  >
-                    Edit
-                  </button>
-                </aside>
-                <hr
-                  class="lbh-horizontal-bar"
-                />
                 <p
                   class="lbh-body-s"
                   data-testid="patch-note"
                 >
-                  From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.
+                  The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.
                 </p>
               </aside>
               <hr
@@ -573,29 +555,11 @@ exports[`it shows the new cautionary alerts icon 1`] = `
                 >
                   Patch details
                 </h2>
-                <p>
-                  No patch
-                </p>
-                <aside
-                  class="mtfh-edit-patch-details"
-                >
-                  <button
-                    class="govuk-button lbh-button"
-                    data-testid="edit-assignment-button"
-                    style="margin-top: 0px;"
-                    type="button"
-                  >
-                    Edit
-                  </button>
-                </aside>
-                <hr
-                  class="lbh-horizontal-bar"
-                />
                 <p
                   class="lbh-body-s"
                   data-testid="patch-note"
                 >
-                  From 6 July 2026, housing services in this area are managed by a Neighbourhood Lead. To raise a query about this property, please use the triage form.
+                  The way Tenancy Services are delivered has changed.  Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action.  We appreciate your patience during this transition.
                 </p>
               </aside>
               <hr


### PR DESCRIPTION
The service has asked for this part of the patches work (removal of patches and associated buttons and alternative text to be displayed instead) to be deployed ASAP.
There is a separate PR for the e2e tests on the dedicated repo.