### PR TITLE
Reverse patch change message on MMH for some accounts

### DIFF
--- a/src/components/asset-sidebar/__snapshots__/index.test.tsx.snap
+++ b/src/components/asset-sidebar/__snapshots__/index.test.tsx.snap
@@ -116,12 +116,6 @@ exports[`Assets Sidebar it hides boiler house details 1`] = `
           >
             No Neighbourhood Area
           </p>
-          <p
-            class="lbh-body-s"
-            data-testid="patch-note"
-          >
-            The way Tenancy Services are delivered has changed. Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action. We appreciate your patience during this transition.
-          </p>
         </aside>
         <hr
           class="lbh-horizontal-bar"
@@ -257,12 +251,6 @@ exports[`Assets Sidebar it hides cautionary alerts 1`] = `
           >
             No Neighbourhood Area
           </p>
-          <p
-            class="lbh-body-s"
-            data-testid="patch-note"
-          >
-            The way Tenancy Services are delivered has changed. Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action. We appreciate your patience during this transition.
-          </p>
         </aside>
         <hr
           class="lbh-horizontal-bar"
@@ -397,12 +385,6 @@ exports[`Assets Sidebar it hides tenure information 1`] = `
             data-testid="no-neighbourhood"
           >
             No Neighbourhood Area
-          </p>
-          <p
-            class="lbh-body-s"
-            data-testid="patch-note"
-          >
-            The way Tenancy Services are delivered has changed. Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action. We appreciate your patience during this transition.
           </p>
         </aside>
         <hr
@@ -555,12 +537,6 @@ exports[`Assets Sidebar it shows boiler house details 1`] = `
             data-testid="no-neighbourhood"
           >
             No Neighbourhood Area
-          </p>
-          <p
-            class="lbh-body-s"
-            data-testid="patch-note"
-          >
-            The way Tenancy Services are delivered has changed. Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action. We appreciate your patience during this transition.
           </p>
         </aside>
         <hr
@@ -732,12 +708,6 @@ exports[`Assets Sidebar it shows cautionary alerts 1`] = `
           >
             No Neighbourhood Area
           </p>
-          <p
-            class="lbh-body-s"
-            data-testid="patch-note"
-          >
-            The way Tenancy Services are delivered has changed. Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action. We appreciate your patience during this transition.
-          </p>
         </aside>
         <hr
           class="lbh-horizontal-bar"
@@ -872,12 +842,6 @@ exports[`Assets Sidebar it shows tenure information 1`] = `
             data-testid="no-neighbourhood"
           >
             No Neighbourhood Area
-          </p>
-          <p
-            class="lbh-body-s"
-            data-testid="patch-note"
-          >
-            The way Tenancy Services are delivered has changed. Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action. We appreciate your patience during this transition.
           </p>
         </aside>
         <hr

--- a/src/components/patch-details/patch-details.test.tsx
+++ b/src/components/patch-details/patch-details.test.tsx
@@ -3,7 +3,7 @@ import * as crypto from "crypto";
 import React from "react";
 
 import { mockAssetV1, render, server } from "@hackney/mtfh-test-utils";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { rest } from "msw";
 
 import { locale } from "../../services";
@@ -145,13 +145,19 @@ describe("Patch Details", () => {
     expect(screen.queryByTestId("all-patches-and-areas-button")).not.toBeInTheDocument();
   });
 
-  test("it shows the explanatory note", async () => {
+  test("it shows the explanatory note when a neighbourhood is provided", async () => {
+    render(<PatchDetails neighbourhood="Hackney North" />);
+
+    await screen.findByText(locale.patchDetails.heading);
+
+    expect(screen.getByTestId("patch-note")).toHaveTextContent(locale.patchDetails.note);
+  });
+
+  test("it does not show the explanatory note when no neighbourhood is provided", async () => {
     render(<PatchDetails neighbourhood={null} />);
 
-    await waitFor(async () => {
-      expect(screen.getByTestId("patch-note")).toHaveTextContent(
-        locale.patchDetails.note,
-      );
-    });
+    await screen.findByText(locale.patchDetails.heading);
+
+    expect(screen.queryByTestId("patch-note")).not.toBeInTheDocument();
   });
 });

--- a/src/components/patch-details/patch-details.tsx
+++ b/src/components/patch-details/patch-details.tsx
@@ -19,22 +19,23 @@ export const PatchDetails = ({ neighbourhood }: Props) => {
         </Heading>
 
         {neighbourhood ? (
-          <SummaryList overrides={[2 / 3]}>
-            <SummaryListItem
-              title={neighbourhoodAreaLabel}
-              data-testid="neighbourhood-name"
-              key="neighbourhoodName"
-            >
-              {neighbourhood}
-            </SummaryListItem>
-          </SummaryList>
+          <>
+            <SummaryList overrides={[2 / 3]}>
+              <SummaryListItem
+                title={neighbourhoodAreaLabel}
+                data-testid="neighbourhood-name"
+                key="neighbourhoodName"
+              >
+                {neighbourhood}
+              </SummaryListItem>
+            </SummaryList>
+            <p className="lbh-body-s" data-testid="patch-note">
+              {locale.patchDetails.note}
+            </p>
+          </>
         ) : (
           <p data-testid="no-neighbourhood">{noNeighbourhoodArea}</p>
         )}
-
-        <p className="lbh-body-s" data-testid="patch-note">
-          {locale.patchDetails.note}
-        </p>
       </aside>
       <hr className="lbh-horizontal-bar" />
     </>

--- a/src/views/asset-view/__snapshots__/layout.test.tsx.snap
+++ b/src/views/asset-view/__snapshots__/layout.test.tsx.snap
@@ -122,12 +122,6 @@ exports[`it hides the cautionary alerts icon 1`] = `
                 >
                   No Neighbourhood Area
                 </p>
-                <p
-                  class="lbh-body-s"
-                  data-testid="patch-note"
-                >
-                  The way Tenancy Services are delivered has changed. Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action. We appreciate your patience during this transition.
-                </p>
               </aside>
               <hr
                 class="lbh-horizontal-bar"
@@ -564,12 +558,6 @@ exports[`it shows the new cautionary alerts icon 1`] = `
                   data-testid="no-neighbourhood"
                 >
                   No Neighbourhood Area
-                </p>
-                <p
-                  class="lbh-body-s"
-                  data-testid="patch-note"
-                >
-                  The way Tenancy Services are delivered has changed. Please direct your enquiry to neighbourhood@hackney.gov.uk so that our Triage Team can assess it and direct it to the most appropriate team for action. We appreciate your patience during this transition.
                 </p>
               </aside>
               <hr


### PR DESCRIPTION
[HT-919](https://hackney.atlassian.net/browse/HT-919) Reverse patch change message on MMH for some accounts

For the ticket, the simplest solution seems to be to only show the patch change message for properties with a neighbourhood.

[HT-919]: https://hackney.atlassian.net/browse/HT-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ