### PR TITLE
Temporarily unlink sonarqube scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,8 +283,8 @@ workflows:
                   context: api-assume-role-housing-development-context
                   requires:
                     #   - security-scan
+                    #   - sonar-scan
                       - lint-and-test
-                      - sonar-scan
                   filters:
                       branches:
                           only: main

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,6 @@ sonar.organization=lbhackney-it
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+
+# Java is already available in the CI image — skip the auto-provisioning download
+sonar.scanner.skipJreProvisioning=true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,6 +10,3 @@ sonar.organization=lbhackney-it
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
-
-# Java is already available in the CI image — skip the auto-provisioning download
-sonar.scanner.skipJreProvisioning=true


### PR DESCRIPTION
Make sonar scan not a requirement to deploy - it's currently experiencing an outage

https://status.sonarqube.com/