### PR TITLE
Handle TMO patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-merge": "5.7.3"
   },
   "engines": {
-    "node": ">=24.0.0 <25.0.0",
+    "node": "^24",
     "yarn": "1.22.22"
   },
   "dependencies": {

--- a/src/components/asset-sidebar/index.tsx
+++ b/src/components/asset-sidebar/index.tsx
@@ -40,8 +40,16 @@ export const AssetSideBar = ({
   showCautionaryAlerts,
   ...properties
 }: Props) => {
-  const { assetAddress, assetId, assetType, tenure, id, assetCharacteristics } =
-    assetDetails;
+  const {
+    assetAddress,
+    assetId,
+    assetType,
+    tenure,
+    id,
+    assetCharacteristics,
+    patchId,
+    areaId,
+  } = assetDetails;
 
   // neighbourhood is not yet in the @mtfh/common AssetAddress type but is returned by the API
   const { neighbourhood } = assetAddress as AssetAddress & { neighbourhood?: string };
@@ -76,7 +84,11 @@ export const AssetSideBar = ({
           <hr className="lbh-horizontal-bar" />
 
           {showCautionaryAlerts && <CautionaryAlertsDetails alerts={alerts} />}
-          <PatchDetails neighbourhood={neighbourhood ?? null} />
+          <PatchDetails
+            neighbourhood={neighbourhood ?? null}
+            patchId={patchId ?? null}
+            areaId={areaId ?? null}
+          />
           <LbhOwnershipInformation asset={assetDetails} />
           {showBoilerHouseInformation() && <BoilerHouseDetails asset={assetDetails} />}
           {showTenureInformation && (

--- a/src/components/patch-details/patch-details.test.tsx
+++ b/src/components/patch-details/patch-details.test.tsx
@@ -2,20 +2,36 @@ import * as crypto from "crypto";
 
 import React from "react";
 
-import { mockAssetV1, render, server } from "@hackney/mtfh-test-utils";
-import { screen } from "@testing-library/react";
+import { render, server } from "@hackney/mtfh-test-utils";
+import { screen, waitFor } from "@testing-library/react";
 import { rest } from "msw";
 
 import { locale } from "../../services";
 import { PatchDetails } from "./patch-details";
 
-import { Asset } from "@mtfh/common/lib/api/asset/v1";
 import { Patch } from "@mtfh/common/lib/api/patch/v1/types";
-import * as auth from "@mtfh/common/lib/auth/auth";
 
 const mockAreaId = crypto.randomBytes(20).toString("hex");
 
-const mockAssetPatch: Patch = {
+const mockAssetPatchTMO: Patch = {
+  id: crypto.randomBytes(20).toString("hex"),
+  name: "AR1",
+  patchType: "tmoPatch",
+  parentId: mockAreaId,
+  domain: "Hackney",
+  responsibleEntities: [
+    {
+      id: crypto.randomBytes(20).toString("hex"),
+      name: "Housing Officer 1",
+      responsibleType: "HousingOfficer",
+      contactDetails: {
+        emailAddress: "test.test@hackney.gov.uk",
+      },
+    },
+  ],
+};
+
+const mockAssetPatchNotTMO: Patch = {
   id: crypto.randomBytes(20).toString("hex"),
   name: "AR1",
   patchType: "patch",
@@ -51,66 +67,26 @@ const mockAssetArea: Patch = {
   ],
 };
 
-const assetWithPatches: Asset = {
-  ...mockAssetV1,
-  patchId: mockAssetPatch.id,
-  areaId: mockAssetArea.id,
-};
-
-const mockPatch: Patch = {
-  id: crypto.randomBytes(20).toString("hex"),
-  name: "HN1",
-  patchType: "patch",
-  parentId: mockAreaId,
-  domain: "Hackney",
-  responsibleEntities: [
-    {
-      id: crypto.randomBytes(20).toString("hex"),
-      name: "Housing Officer 1",
-      responsibleType: "HousingOfficer",
-      contactDetails: {
-        emailAddress: "test.test@hackney.gov.uk",
-      },
-    },
-  ],
-};
-
-const mockPatchList: Patch[] = [mockPatch, mockAssetPatch];
-
 // Mock the API response for the patch list
 beforeEach(() => {
-  jest.resetAllMocks();
-
-  jest.spyOn(auth, "isAuthorisedForGroups").mockReturnValue(true);
-
   server.use(
-    rest.get(`/api/v1/patch/${mockAssetPatch.id}`, (req, res, ctx) =>
-      res(ctx.status(200), ctx.json(mockAssetPatch)),
+    rest.get(`/api/v1/patch/${mockAssetPatchTMO.id}`, (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(mockAssetPatchTMO)),
     ),
   );
   server.use(
-    rest.get(`/api/v1/patch/${mockAssetPatch.parentId}`, (req, res, ctx) =>
+    rest.get(`/api/v1/patch/${mockAssetPatchNotTMO.id}`, (req, res, ctx) =>
+      res(ctx.status(200), ctx.json(mockAssetPatchNotTMO)),
+    ),
+  );
+  server.use(
+    rest.get(`/api/v1/patch/${mockAssetPatchTMO.parentId}`, (req, res, ctx) =>
       res(ctx.status(200), ctx.json(mockAssetArea)),
-    ),
-  );
-  server.use(
-    rest.get("/api/v1/patch/all", (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json(mockPatchList));
-    }),
-  );
-  server.use(
-    rest.get(`/api/v1/patch/patchName/*`, (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json(mockPatch));
-    }),
-  );
-  server.use(
-    rest.patch(`/api/v1/assets/${assetWithPatches.id}/patch`, (req, res, ctx) =>
-      res(ctx.status(204)),
     ),
   );
 });
 
-describe("Patch Details", () => {
+describe("Patch Details - Neighbourhood mode", () => {
   test("it renders the component", async () => {
     render(<PatchDetails neighbourhood={null} />);
 
@@ -159,5 +135,98 @@ describe("Patch Details", () => {
     await screen.findByText(locale.patchDetails.heading);
 
     expect(screen.queryByTestId("patch-note")).not.toBeInTheDocument();
+  });
+
+  test("it does not show TMO elements when not assigned to TMO patch", async () => {
+    render(<PatchDetails neighbourhood="Hackney North" />);
+
+    await screen.findByText(locale.patchDetails.heading);
+
+    expect(screen.queryByTestId("patch-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("officer-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("area-manager-name")).not.toBeInTheDocument();
+  });
+});
+
+describe("Patch Details - Assigned to TMO patch", () => {
+  test("it renders the component with patch and area details", async () => {
+    render(
+      <PatchDetails
+        neighbourhood={null}
+        patchId={mockAssetPatchTMO.id}
+        areaId={mockAssetArea.id}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("patch-name")).toHaveTextContent(mockAssetPatchTMO.name);
+    });
+
+    expect(screen.getByTestId("officer-name")).toHaveTextContent(
+      mockAssetPatchTMO.responsibleEntities[0].name,
+    );
+    expect(screen.getByTestId("area-manager-name")).toHaveTextContent(
+      mockAssetArea.responsibleEntities[0].name,
+    );
+  });
+
+  test("it does not show neighbourhood-specific elements", async () => {
+    render(
+      <PatchDetails
+        neighbourhood={null}
+        patchId={mockAssetPatchTMO.id}
+        areaId={mockAssetArea.id}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("patch-name")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("neighbourhood-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("no-neighbourhood")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("patch-note")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("edit-assignment-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("all-patches-and-areas-button")).not.toBeInTheDocument();
+  });
+});
+
+describe("Patch Details - Assigned to non-TMO patch", () => {
+  test("it shows neighbourhood content when patch is not a TMO patch", async () => {
+    render(
+      <PatchDetails
+        neighbourhood="Hackney North"
+        patchId={mockAssetPatchNotTMO.id}
+        areaId={mockAssetArea.id}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("neighbourhood-name")).toHaveTextContent("Hackney North");
+    });
+
+    expect(screen.getByTestId("patch-note")).toHaveTextContent(locale.patchDetails.note);
+    expect(screen.queryByTestId("patch-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("officer-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("area-manager-name")).not.toBeInTheDocument();
+  });
+
+  test("it shows 'No Housing Management Area' when neighbourhood is null for non-TMO patch", async () => {
+    render(
+      <PatchDetails
+        neighbourhood={null}
+        patchId={mockAssetPatchNotTMO.id}
+        areaId={mockAssetArea.id}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("no-neighbourhood")).toHaveTextContent(
+        locale.patchDetails.noNeighbourhoodArea,
+      );
+    });
+
+    expect(screen.queryByTestId("patch-note")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("patch-name")).not.toBeInTheDocument();
   });
 });

--- a/src/components/patch-details/patch-details.test.tsx
+++ b/src/components/patch-details/patch-details.test.tsx
@@ -13,10 +13,10 @@ import { Patch } from "@mtfh/common/lib/api/patch/v1/types";
 
 const mockAreaId = crypto.randomBytes(20).toString("hex");
 
-const mockAssetPatchTMO: Patch = {
+const mockAssetPatch = (isTmo: boolean): Patch => ({
   id: crypto.randomBytes(20).toString("hex"),
   name: "AR1",
-  patchType: "tmoPatch",
+  patchType: isTmo ? "tmoPatch" : "patch",
   parentId: mockAreaId,
   domain: "Hackney",
   responsibleEntities: [
@@ -29,25 +29,10 @@ const mockAssetPatchTMO: Patch = {
       },
     },
   ],
-};
+});
 
-const mockAssetPatchNotTMO: Patch = {
-  id: crypto.randomBytes(20).toString("hex"),
-  name: "AR1",
-  patchType: "patch",
-  parentId: mockAreaId,
-  domain: "Hackney",
-  responsibleEntities: [
-    {
-      id: crypto.randomBytes(20).toString("hex"),
-      name: "Housing Officer 1",
-      responsibleType: "HousingOfficer",
-      contactDetails: {
-        emailAddress: "test.test@hackney.gov.uk",
-      },
-    },
-  ],
-};
+const mockAssetPatchTMO = mockAssetPatch(true);
+const mockAssetPatchNotTMO = mockAssetPatch(false);
 
 const mockAssetArea: Patch = {
   id: mockAreaId,

--- a/src/components/patch-details/patch-details.tsx
+++ b/src/components/patch-details/patch-details.tsx
@@ -2,42 +2,90 @@ import React from "react";
 
 import { locale } from "../../services";
 
+import { Patch } from "@mtfh/common/lib/api/patch/v1/types";
 import { Heading, SummaryList, SummaryListItem } from "@mtfh/common/lib/components";
+import { config } from "@mtfh/common/lib/config";
+import { useAxiosSWR } from "@mtfh/common/lib/http";
+
+const usePatchOrArea = (id: string | null) =>
+  useAxiosSWR<Patch>(id ? `${config.patchesAndAreasApiUrlV1}/patch/${id}` : null);
 
 interface Props {
   neighbourhood: string | null;
+  patchId?: string | null;
+  areaId?: string | null;
 }
 
-export const PatchDetails = ({ neighbourhood }: Props) => {
-  const { heading, neighbourhoodAreaLabel, noNeighbourhoodArea } = locale.patchDetails;
+const PatchInfo = ({ children }: { children: React.ReactNode }) => (
+  <>
+    <aside className="mtfh-patch-details">
+      <Heading variant="h2" className="lbh-heading lbh-heading-h3">
+        {locale.patchDetails.heading}
+      </Heading>
+      {children}
+    </aside>
+    <hr className="lbh-horizontal-bar" />
+  </>
+);
 
+export const PatchDetails = ({ neighbourhood, patchId, areaId }: Props) => {
+  const { data: assetPatch } = usePatchOrArea(patchId ?? null);
+  const { data: assetArea } = usePatchOrArea(areaId ?? null);
+
+  const { patchLabel, housingOfficerLabel, areaManagerLabel } = locale.patchDetails;
+
+  const housingOfficerName = assetPatch?.responsibleEntities?.[0]?.name;
+  const areaManagerName = assetArea?.responsibleEntities?.[0]?.name;
+
+  const isTmo = assetPatch?.patchType === "tmoPatch";
+
+  if (isTmo) {
+    return (
+      <PatchInfo>
+        <SummaryList overrides={[2 / 3]}>
+          <SummaryListItem title={patchLabel} data-testid="patch-name" key="patchName">
+            {assetPatch?.name}
+          </SummaryListItem>
+          <SummaryListItem
+            title={housingOfficerLabel}
+            data-testid="officer-name"
+            key="officerName"
+          >
+            {housingOfficerName || "N/A"}
+          </SummaryListItem>
+          <SummaryListItem
+            title={areaManagerLabel}
+            data-testid="area-manager-name"
+            key="areaManagerName"
+          >
+            {areaManagerName || "N/A"}
+          </SummaryListItem>
+        </SummaryList>
+      </PatchInfo>
+    );
+  }
+
+  const { neighbourhoodAreaLabel, noNeighbourhoodArea } = locale.patchDetails;
   return (
-    <>
-      <aside className="mtfh-patch-details">
-        <Heading variant="h2" className="lbh-heading lbh-heading-h3">
-          {heading}
-        </Heading>
-
-        {neighbourhood ? (
-          <>
-            <SummaryList overrides={[2 / 3]}>
-              <SummaryListItem
-                title={neighbourhoodAreaLabel}
-                data-testid="neighbourhood-name"
-                key="neighbourhoodName"
-              >
-                {neighbourhood}
-              </SummaryListItem>
-            </SummaryList>
-            <p className="lbh-body-s" data-testid="patch-note">
-              {locale.patchDetails.note}
-            </p>
-          </>
-        ) : (
-          <p data-testid="no-neighbourhood">{noNeighbourhoodArea}</p>
-        )}
-      </aside>
-      <hr className="lbh-horizontal-bar" />
-    </>
+    <PatchInfo>
+      {neighbourhood ? (
+        <>
+          <SummaryList overrides={[2 / 3]}>
+            <SummaryListItem
+              title={neighbourhoodAreaLabel}
+              data-testid="neighbourhood-name"
+              key="neighbourhoodName"
+            >
+              {neighbourhood}
+            </SummaryListItem>
+          </SummaryList>
+          <p className="lbh-body-s" data-testid="patch-note">
+            {locale.patchDetails.note}
+          </p>
+        </>
+      ) : (
+        <p data-testid="no-neighbourhood">{noNeighbourhoodArea}</p>
+      )}
+    </PatchInfo>
   );
 };


### PR DESCRIPTION
[HT-919](https://hackney.atlassian.net/browse/HT-919)

For properties assigned to TMO patches, we want to display the patch and area as before, and not display the new neighbourhood property.

We did not expect that the list of properties assigned to neighbourhoods would include TMO properties.

[HT-919]: https://hackney.atlassian.net/browse/HT-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

```mermaid
flowchart TD
    Start(["PatchDetails(neighbourhood, patchId, areaId)"])
    
    Fetch["Get Patch and Area"]
    
    Check{"assetPatch?.patchType<br>=== 'tmoPatch'?"}
    
    TMO["TMO Patch View
    ─────────────────
    • Patch name (assetPatch.name)
    • Housing Officer (or N/A)
    • Area Manager (or N/A)"]
    
    HasNeighbourhood{"neighbourhood<br>present?"}
    
    NeighbourhoodYes["Neighbourhood View
    ─────────────────
    • Neighbourhood name
    • Explanatory note"]
    
    NeighbourhoodNo["Neighbourhood View
    ─────────────────
    • 'No Housing Management Area'"]

    Start --> Fetch --> Check
    Check -->|Yes| TMO
    Check -->|No| HasNeighbourhood
    HasNeighbourhood -->|Yes| NeighbourhoodYes
    HasNeighbourhood -->|No| NeighbourhoodNo
```